### PR TITLE
Update 3.12.0-RELEASE to mitigate against high vuln CVEs

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,19 +1,31 @@
-version: 1
+version: 2
+registries:
+  maven-github:
+    type: maven-repository
+    url: https://nexus.adaptris.net/nexus/content/groups/interlok
+    username: dummy
+    password: dummy-since-this-is-a-public-repo
 
-update_configs:
-  - package_manager: "java:gradle"
+updates:
+  - package-ecosystem: "gradle"
     directory: "/v4"
-    update_schedule: "daily"
-    default_reviewers:
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "all"
+    reviewers:
       - quotidian-ennui
       - mcwarman
       - aaron-mcgrath-adp
       - sebastien-belin-adp
       - higgyfella
-  - package_manager: "java:gradle"
+  - package-ecosystem: "gradle"
     directory: "/v3"
-    update_schedule: "daily"
-    default_reviewers:
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "all"
+    reviewers:
       - quotidian-ennui
       - mcwarman
       - aaron-mcgrath-adp

--- a/v3/build.gradle
+++ b/v3/build.gradle
@@ -192,7 +192,15 @@ dependencies {
   interlokRuntime ("com.sun.activation:jakarta.activation:1.2.2")
   interlokRuntime ("jakarta.validation:jakarta.validation-api:2.0.2")
 
+  interlokRuntime ("org.eclipse.jetty.aggregate:jetty-all:9.4.40.v20210413")
+  interlokRuntime ("com.thoughtworks.xstream:xstream:1.4.16")
+
+  interlokRuntime ("org.apache.activemq:activemq-client:5.16.2") {
+    exclude group: "org.apache.geronimo.specs", module: "geronimo-jms_1.1_spec"
+  }
+
   interlokTestRuntime ("com.adaptris:interlok-service-tester:$interlokVersion") { changing=true }
+
   interlokWar  ("com.adaptris.ui:interlok:$interlokUiVersion@war") {changing=true}
 
   interlokVerify files("$interlokTmpConfigDirectory"){

--- a/v3/build.gradle
+++ b/v3/build.gradle
@@ -481,8 +481,20 @@ dependencyCheck  {
   suppressionFiles= [ "https://raw.githubusercontent.com/adaptris/interlok/develop/gradle/owasp-exclude.xml" ]
   scanConfigurations = buildDetails.isIncludeWar() ? [ "interlokWar", "interlokRuntime" ] : [ "interlokRuntime" ]
   failBuildOnCVSS = 7
+  formats = [ "HTML", "JUNIT" ]
+  analyzers {
+    assemblyEnabled=false
+  }
+}
+
+task checkInterlokVersion {
+  doLast {
+    if (interlokVersion.startsWith("4")) {
+      throw new GradleException("Interlok 4+; Switch to using 'https://raw.githubusercontent.com/adaptris/interlok-build-parent/main/v4/build.gradle' instead")
+    }
+  }
 }
 
 // check.dependsOn dependencyCheckAnalyze,interlokVerify,interlokServiceTest,interlokVersionReport
-check.dependsOn interlokVerify,interlokServiceTest,interlokVersionReport
+check.dependsOn checkInterlokVersion,interlokVerify,interlokServiceTest,interlokVersionReport
 assemble.dependsOn installDist

--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -483,6 +483,10 @@ dependencyCheck  {
   suppressionFiles= [ "https://raw.githubusercontent.com/adaptris/interlok/develop/gradle/owasp-exclude.xml" ]
   scanConfigurations = buildDetails.isIncludeWar() ? [ "interlokWar", "interlokRuntime" ] : [ "interlokRuntime" ]
   failBuildOnCVSS = 7
+  formats = [ "HTML", "JUNIT" ]
+  analyzers {
+    assemblyEnabled=false
+  }
 }
 
 // check.dependsOn dependencyCheckAnalyze,interlokVerify,interlokServiceTest,interlokVersionReport


### PR DESCRIPTION
## Motivation

v3/build.gradle doesn't pass `dependencyCheckAnalyze` 

## Modification

- Bump xstream + jetty to the latest versions so CVE's are no longer an issue for 3.12.0-RELEASE
- Add protection to v3/build.gradle such that we "fail" when the version is 4+
- Modify dependencyCheck configuration so that both JUNIT + HTML reports
- Modify dependencyCheck config so that assemblers aren't analyzed.

## PR Checklist

- [x] been self-reviewed.

## Result

`gradle dependencyCheckAnalyze` will no longer fail.

## Testing

Use https://github.com/adaptris-labs/build-parent-json-csv as your template
- Change the parent URL to `https://raw.githubusercontent.com/adaptris/interlok-build-parent/main/v3/build.gradle`
- make includeWar = false
- `gradle dependencyCheckAnalyze` -> it will fail because of xstream and websockets
- Change parent URL to `https://raw.githubusercontent.com/adaptris/interlok-build-parent/develop/v3/build.gradle`
- `gradle dependencyCheckAnalyze` -> it will now pass
- Change interlokVersion = "4.0.0-RELEASE"
- `gradle check` should now fail early




