### PR TITLE
Pin service tester to an explicit version

### DIFF
--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -17,9 +17,14 @@ ext {
   nexusBaseUrl  = 'https://nexus.adaptris.net'
   log4j2Version='2.14.1'
   slf4jVersion='1.7.32'
+  // Make interlokServiceTester an explicit version
+  // If interlokVersion == SNAPSHOT then server-tester follows snapshot, otherwise it should
+  // be pinned to it's own release.
   interlokVersion = project.findProperty('interlokVersion') ?: '4.2.0-RELEASE'
-  verifyReportConfigCheckAvailable = '3.12-SNAPSHOT'
+  interlokServiceTesterVersion = project.findProperty('interlokServiceTesterVersion') ?: '4.2.1-RELEASE'
   interlokUiVersion = project.findProperty('interlokUiVersion') ?: interlokVersion
+  verifyReportConfigCheckAvailable = '3.12-SNAPSHOT'
+
   interlokSourceConfig = "${projectDir}/src/main/interlok/config"
   interlokTmpConfigDirectory = "${buildDir}/tmp/config"
   interlokTmpLibDirectory = "${buildDir}/tmp/lib"
@@ -197,7 +202,12 @@ dependencies {
   // CVE-2021-39139 (4.2-SNAPSHOT is already at 1.4.18)
   interlokRuntime ("com.thoughtworks.xstream:xstream:1.4.18")
 
-  interlokTestRuntime ("com.adaptris:interlok-service-tester:$interlokVersion") { changing=true }
+  if (interlokVersion.endsWith("SNAPSHOT")) {
+    interlokTestRuntime ("com.adaptris:interlok-service-tester:$interlokVersion") { changing=true }
+  } else {
+    interlokTestRuntime ("com.adaptris:interlok-service-tester:$interlokServiceTesterVersion") { changing=true }
+  }
+
   interlokWar  ("com.adaptris.ui:interlok:$interlokUiVersion@war") {changing=true}
 
   interlokVerify files("$interlokTmpConfigDirectory"){

--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -24,6 +24,7 @@ ext {
   interlokServiceTesterVersion = project.findProperty('interlokServiceTesterVersion') ?: '4.2.1-RELEASE'
   interlokUiVersion = project.findProperty('interlokUiVersion') ?: interlokVersion
   verifyReportConfigCheckAvailable = '3.12-SNAPSHOT'
+  requiresServiceTesterPatch = "4.2.0-RELEASE"
 
   interlokSourceConfig = "${projectDir}/src/main/interlok/config"
   interlokTmpConfigDirectory = "${buildDir}/tmp/config"
@@ -63,6 +64,10 @@ ext.buildDetails = [
 
   isIncludeWar: { ->
     return includeWar.equals("true") || buildEnv.equals("dev")
+  },
+
+  hasServiceTesterPatch: { ->
+    return VersionNumber.parse( interlokVersion ) == VersionNumber.parse( requiresServiceTesterPatch )
   }
 
 ]
@@ -202,7 +207,12 @@ dependencies {
   // CVE-2021-39139 (4.2-SNAPSHOT is already at 1.4.18)
   interlokRuntime ("com.thoughtworks.xstream:xstream:1.4.18")
 
-  if (interlokVersion.endsWith("SNAPSHOT")) {
+  // The hasServiceTesterPatch() condition should become redundant for 4.3.0-RELEASE
+  // since dependabot should auto-upgrade to 4.3.0-RELEASE for service tester as well.
+  // Expectation is 4.1.0-RELEASE -> 4.1.0 for both interlok-core & service-tester
+  // 4.2.0-RELEASE -> interlok-core, service-tester=4.2.1-RELEASE
+  // 4.3-SNAPSHOT -> interlok-core + service-tester == 4.3-SNAPSHOT
+  if (interlokVersion.endsWith("SNAPSHOT") || !buildDetails.hasServiceTesterPatch()) {
     interlokTestRuntime ("com.adaptris:interlok-service-tester:$interlokVersion") { changing=true }
   } else {
     interlokTestRuntime ("com.adaptris:interlok-service-tester:$interlokServiceTesterVersion") { changing=true }


### PR DESCRIPTION
## Motivation

Because service-tester was broken at 4.2.0, it is now 4.2.1-RELEASE. We need to pin to that version otherwise service tester is broken and you can't run any tests.

## Modification

- There is now an interlokServiceTesterVersion variable pinned at 4.2.1-RELEASE
- If interlokVersion ends in SNAPSHOT then we don't use interlokServiceTesterVersion

Post merge into develop this needs to be merged into master.

## PR Checklist

- [x] been self-reviewed.
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader

## Result

- If they do nothing they get 4.2.1-RELEASE
- They can now pin their version at whatever they want.
- Not sure what the ramifications are on dependabot, this change could be reverted when 4.3.0-RELEASE is published.
- Side effect is that we currently have no idea what happens if 4.2.1-RELEASE of interlokVersion happens before 4.3.0-RELEASE...


## Testing

Create gradle project using this branch 

```
ext {
  interlokParentGradle = 'https://raw.githubusercontent.com/adaptris/interlok-build-parent/service-tester-explicit-version/v4/build.gradle'
  // interlokVersion = '4.3-SNAPSHOT'
}
allprojects {
  apply from: "${interlokParentGradle}"
}
```

- Do `gradle -PbuildEnv=dev clean assemble`
- `cd build/distribution && java -jar lib/interlok-boot.jar -version`
- Service Tester should be pinned at 4.2.1-RELEASE

```
Bootstrap of Interlok 4.2.0-RELEASE(2021-09-03:4.2.0) complete
Version Information
  Interlok Config/variable substitutions: 4.2.0-RELEASE(2021-09-03:4.2.0)
  Interlok Config/xinclude: 4.2.0-RELEASE(2021-09-03:4.2.0)
  Interlok Core/Annotations: 4.2.0-RELEASE(2021-09-03:4.2.0)
  Interlok Core/Base: 4.2.0-RELEASE(2021-09-03:4.2.0)
  Interlok Core/Bootstrap: 4.2.0-RELEASE(2021-09-03:4.2.0)
  Interlok Core/Client: 4.2.0-RELEASE(2021-09-03:4.2.0)
  Interlok Core/Common: 4.2.0-RELEASE(2021-09-03:4.2.0)
  Interlok Core/JMX Client: 4.2.0-RELEASE(2021-09-03:4.2.0)
  Interlok Core/Logging: 4.2.0-RELEASE(2021-09-03:4.2.0)
  Interlok HTTP/Apache HTTP(4): 4.2.0-RELEASE(2021-09-03:4.2.0)
  Interlok Management/REST: Base: 4.2.0-RELEASE(2021-09-03:4.2.0)
  Interlok Management/REST: Health Check: 4.2.0-RELEASE(2021-09-03:4.2.0)
  Interlok Service Tester/Core: 4.2.1-RELEASE(2021-09-14:08:51:24 BST)
  Interlok Transform/JSON: 4.2.0-RELEASE(2021-09-03:4.2.0)
```

Uncomment the interlokVersion so that we're pinned at 4.3-SNAPSHOT, and run the commands again

- Service Tester should be pinned at 4.3-SNAPSHOT

```
Bootstrap of Interlok 4.3-SNAPSHOT(2021-09-15:04:27:58 BST) complete
Version Information
  Interlok Config/variable substitutions: 4.3-SNAPSHOT(2021-09-15:04:41:05 BST)
  Interlok Config/xinclude: 4.3-SNAPSHOT(2021-09-15:04:41:40 BST)
  Interlok Core/Annotations: 4.3-SNAPSHOT(2021-09-15:04:27:13 BST)
  Interlok Core/Base: 4.3-SNAPSHOT(2021-09-15:04:27:58 BST)
  Interlok Core/Bootstrap: 4.3-SNAPSHOT(2021-09-15:04:27:14 BST)
  Interlok Core/Client: 4.3-SNAPSHOT(2021-09-15:04:27:20 BST)
  Interlok Core/Common: 4.3-SNAPSHOT(2021-09-15:04:27:21 BST)
  Interlok Core/JMX Client: 4.3-SNAPSHOT(2021-09-15:04:27:23 BST)
  Interlok Core/Logging: 4.3-SNAPSHOT(2021-09-15:04:37:25 BST)
  Interlok HTTP/Apache HTTP(4): 4.3-SNAPSHOT(2021-09-15:04:41:11 BST)
  Interlok Management/REST: Base: 4.3-SNAPSHOT(2021-09-15:04:56:12 BST)
  Interlok Management/REST: Health Check: 4.3-SNAPSHOT(2021-09-15:04:56:32 BST)
  Interlok Service Tester/Core: 4.3-SNAPSHOT(2021-09-15:04:47:08 BST)
  Interlok Transform/JSON: 4.3-SNAPSHOT(2021-09-15:04:42:03 BST)
```

- Pin interlokVersion as "4.1.0-RELEASE", service-tester stays at 4.1.0-RELEASE

```
Bootstrap of Interlok 4.1.0-RELEASE(2021-06-21:12:33:34 BST) complete
Version Information
  Interlok Config/variable substitutions: 4.1.0-RELEASE(2021-06-21:12:47:44 BST)
  Interlok Config/xinclude: 4.1.0-RELEASE(2021-06-21:12:47:40 BST)
  Interlok Core/Annotations: 4.1.0-RELEASE(2021-06-21:12:32:52 BST)
  Interlok Core/Base: 4.1.0-RELEASE(2021-06-21:12:33:34 BST)
  Interlok Core/Bootstrap: 4.1.0-RELEASE(2021-06-21:12:32:54 BST)
  Interlok Core/Client: 4.1.0-RELEASE(2021-06-21:12:32:59 BST)
  Interlok Core/Common: 4.1.0-RELEASE(2021-06-21:12:32:58 BST)
  Interlok Core/JMX Client: 4.1.0-RELEASE(2021-06-21:12:33:02 BST)
  Interlok Core/Logging: 4.1.0-RELEASE(2021-06-21:12:43:05 BST)
  Interlok HTTP/Apache HTTP(4): 4.1.0-RELEASE(2021-06-21:12:47:05 BST)
  Interlok Management/REST: Base: 4.1.0-RELEASE(2021-06-21:13:02:11 BST)
  Interlok Management/REST: Health Check: 4.1.0-RELEASE(2021-06-21:13:02:31 BST)
  Interlok Service Tester/Core: 4.1.0-RELEASE(2021-06-21:12:53:10 BST)
  Interlok Transform/JSON: 4.1.0-RELEASE(2021-06-21:12:48:32 BST)
```