### PR TITLE
INTERLOK-3856 Add java-library plugin to deal with dependencies with variant

### DIFF
--- a/v3/build.gradle
+++ b/v3/build.gradle
@@ -11,6 +11,7 @@ buildscript {
 
 apply plugin: org.owasp.dependencycheck.gradle.DependencyCheckPlugin
 apply plugin: "distribution"
+apply plugin: "java-library"
 
 ext {
   localInterlokRepo = project.findProperty('localInterlokRepo') ?: 'unknown'

--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -11,6 +11,7 @@ buildscript {
 
 apply plugin: org.owasp.dependencycheck.gradle.DependencyCheckPlugin
 apply plugin: "distribution"
+apply plugin: "java-library"
 
 ext {
   localInterlokRepo = project.findProperty('localInterlokRepo') ?: 'unknown'


### PR DESCRIPTION
## Motivation

When we include interlok-gcloud-pubsub in a gradle file that depend on interlok-build-parent we get an error.
So with something as simple as:

```gradle
ext {
  interlokVersion = project.findProperty("interlokVersion") ?: "4.3.0B1-RELEASE"

  interlokParentGradle = "https://raw.githubusercontent.com/adaptris/interlok-build-parent/1.8.2/v4/build.gradle"
}

allprojects {
  apply from: "${interlokParentGradle}"
}

dependencies {
  interlokRuntime ("com.adaptris:interlok-gcloud-pubsub:$interlokVersion") { changing=true }

  interlokJavadocs ("com.adaptris:interlok-gcloud-pubsub:$interlokVersion:javadoc") { changing=true; transitive=false }
}
```

When we run `gradle clean assemble`

We get an error:

```sh
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':installDist'.
> Could not resolve all files for configuration ':interlokRuntime'.
   > Could not resolve com.google.api:gax:2.6.1.
     Required by:
         project : > com.adaptris:interlok-gcloud-pubsub:4.3.0B1-RELEASE > com.google.cloud:google-cloud-pubsub:1.114.7
      > Cannot choose between the following variants of com.google.api:gax:2.6.1:
          - runtimeElements
          - shadowRuntimeElements
        All of them match the consumer attributes:
          - Variant 'runtimeElements' capability com.google.api:gax:2.6.1:
              - Unmatched attributes:
                  - Provides org.gradle.category 'library' but the consumer didn't ask for it
                  - Provides org.gradle.dependency.bundling 'external' but the consumer didn't ask for it
                  - Provides org.gradle.jvm.version '8' but the consumer didn't ask for it
                  - Provides org.gradle.libraryelements 'jar' but the consumer didn't ask for it
                  - Provides org.gradle.status 'release' but the consumer didn't ask for it
                  - Provides org.gradle.usage 'java-runtime' but the consumer didn't ask for it
          - Variant 'shadowRuntimeElements' capability com.google.api:gax:2.6.1:
              - Unmatched attributes:
                  - Provides org.gradle.category 'library' but the consumer didn't ask for it
                  - Provides org.gradle.dependency.bundling 'shadowed' but the consumer didn't ask for it
                  - Provides org.gradle.libraryelements 'jar' but the consumer didn't ask for it
                  - Provides org.gradle.status 'release' but the consumer didn't ask for it
                  - Provides org.gradle.usage 'java-runtime' but the consumer didn't ask for it
   > Could not resolve com.google.api:gax-grpc:2.6.1.
     Required by:
         project : > com.adaptris:interlok-gcloud-pubsub:4.3.0B1-RELEASE > com.google.cloud:google-cloud-pubsub:1.114.7
      > Cannot choose between the following variants of com.google.api:gax-grpc:2.6.1:
          - runtimeElements
          - shadowRuntimeElements
        All of them match the consumer attributes:
          - Variant 'runtimeElements' capability com.google.api:gax-grpc:2.6.1:
              - Unmatched attributes:
                  - Provides org.gradle.category 'library' but the consumer didn't ask for it
                  - Provides org.gradle.dependency.bundling 'external' but the consumer didn't ask for it
                  - Provides org.gradle.jvm.version '8' but the consumer didn't ask for it
                  - Provides org.gradle.libraryelements 'jar' but the consumer didn't ask for it
                  - Provides org.gradle.status 'release' but the consumer didn't ask for it
                  - Provides org.gradle.usage 'java-runtime' but the consumer didn't ask for it
          - Variant 'shadowRuntimeElements' capability com.google.api:gax-grpc:2.6.1:
              - Unmatched attributes:
                  - Provides org.gradle.category 'library' but the consumer didn't ask for it
                  - Provides org.gradle.dependency.bundling 'shadowed' but the consumer didn't ask for it
                  - Provides org.gradle.libraryelements 'jar' but the consumer didn't ask for it
                  - Provides org.gradle.status 'release' but the consumer didn't ask for it
                  - Provides org.gradle.usage 'java-runtime' but the consumer didn't ask for it

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 6s
7 actionable tasks: 6 executed, 1 up-to-date
```

The reason is that some of its dependencies (e.g. com.google.api:gax) have a shadow (uber jar) variant of the jar file and our parent build doesn't handle it. However the java-library plugin does.

## Modification

Apply the java-library plugin.

## Result

We can use interlok-gcloud-pubsub as an interlokRuntime dependency when using interlok-build-parent

## Testing

Create a build.gradle with

```gradle
ext {
  interlokVersion = project.findProperty("interlokVersion") ?: "4.3.0B1-RELEASE"

  interlokParentGradle = "https://raw.githubusercontent.com/adaptris/interlok-build-parent/feature/INTERLOK-3856-gcloud-pub-sub-doesnt-work-with-gradle-parent/v4/build.gradle"
}

allprojects {
  apply from: "${interlokParentGradle}"
}

dependencies {
  interlokRuntime ("com.adaptris:interlok-gcloud-pubsub:$interlokVersion") { changing=true }

  interlokJavadocs ("com.adaptris:interlok-gcloud-pubsub:$interlokVersion:javadoc") { changing=true; transitive=false }
}
```

and run `gradle clean assemble`. That should work fine, you should have an interlok install in the `build/distribution` dir.
