### PR TITLE
INTERLOK-3853 #comment Add index when jar name already exists

### DIFF
--- a/v3/build.gradle
+++ b/v3/build.gradle
@@ -415,7 +415,7 @@ task interlokServiceTestReport {
 
       ant.junitreport(todir: "$buildDir/reports/html") {
         fileset(dir: "$buildDir/reports/unit", includes: 'TEST-*.xml')
-        report(todir: "$buildDir/reports/html", format: "frames"	)
+        report(todir: "$buildDir/reports/html", format: "frames")
       }
     }
 }
@@ -465,21 +465,21 @@ distributions {
             into('docs/javadocs') {
               from(interlokJavadocsDist)
             }
-			// Doing: rename '(.*)-[0-9]+\\..*.jar', '$1.jar'
-			// but also add an index if a file name already exists
-			rename { filename ->
+            // Doing: rename '(.*)-[0-9]+\\..*.jar', '$1.jar'
+            // but also add an index if a file name already exists
+            rename { filename ->
                 if (filename ==~ '(.*)\\.jar') {
                     def name = filename.replaceFirst('(.*)-[0-9]+\\..*.jar', '$1')
                     def extension = 'jar'
-					filename = "${name}.${extension}"
+                    filename = "${name}.${extension}"
                     def index = 1
                     while (!usedFileNames.add(filename)) {
                         filename = "${name}_${index}.${extension}"
                         index++
                     }
                 }
-				return filename
-			}
+                return filename
+            }
             rename '(.*)-[0-9]+\\..*.war', '$1.war'
             duplicatesStrategy = DuplicatesStrategy.EXCLUDE
         }

--- a/v3/build.gradle
+++ b/v3/build.gradle
@@ -447,6 +447,7 @@ task interlokJavadocsDist(type: Copy) {
 distributions {
     main {
         contents {
+            def usedFileNames = new HashSet()
             into('') {
                 from ("src/main/interlok")
                 exclude "config"
@@ -464,7 +465,21 @@ distributions {
             into('docs/javadocs') {
               from(interlokJavadocsDist)
             }
-            rename '(.*)-[0-9]+\\..*.jar', '$1.jar'
+			// Doing: rename '(.*)-[0-9]+\\..*.jar', '$1.jar'
+			// but also add an index if a file name already exists
+			rename { filename ->
+                if (filename ==~ '(.*)\\.jar') {
+                    def name = filename.replaceFirst('(.*)-[0-9]+\\..*.jar', '$1')
+                    def extension = 'jar'
+					filename = "${name}.${extension}"
+                    def index = 1
+                    while (!usedFileNames.add(filename)) {
+                        filename = "${name}_${index}.${extension}"
+                        index++
+                    }
+                }
+				return filename
+			}
             rename '(.*)-[0-9]+\\..*.war', '$1.war'
             duplicatesStrategy = DuplicatesStrategy.EXCLUDE
         }

--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -429,7 +429,7 @@ task interlokServiceTestReport {
 
       ant.junitreport(todir: "$buildDir/reports/html") {
         fileset(dir: "$buildDir/reports/unit", includes: 'TEST-*.xml')
-        report(todir: "$buildDir/reports/html", format: "frames"	)
+        report(todir: "$buildDir/reports/html", format: "frames")
       }
     }
 }
@@ -479,21 +479,21 @@ distributions {
             into('docs/javadocs') {
               from(interlokJavadocsDist)
             }
-			// Doing: rename '(.*)-[0-9]+\\..*.jar', '$1.jar'
-			// but also add an index if a file name already exists
-			rename { filename ->
+            // Doing: rename '(.*)-[0-9]+\\..*.jar', '$1.jar'
+            // but also add an index if a file name already exists
+            rename { filename ->
                 if (filename ==~ '(.*)\\.jar') {
                     def name = filename.replaceFirst('(.*)-[0-9]+\\..*.jar', '$1')
                     def extension = 'jar'
-					filename = "${name}.${extension}"
+                    filename = "${name}.${extension}"
                     def index = 1
                     while (!usedFileNames.add(filename)) {
                         filename = "${name}_${index}.${extension}"
                         index++
                     }
                 }
-				return filename
-			}
+                return filename
+            }
             rename '(.*)-[0-9]+\\..*.war', '$1.war'
             duplicatesStrategy = DuplicatesStrategy.EXCLUDE
         }

--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -461,6 +461,7 @@ task interlokJavadocsDist(type: Copy) {
 distributions {
     main {
         contents {
+            def usedFileNames = new HashSet()
             into('') {
                 from ("src/main/interlok")
                 exclude "config"
@@ -478,7 +479,21 @@ distributions {
             into('docs/javadocs') {
               from(interlokJavadocsDist)
             }
-            rename '(.*)-[0-9]+\\..*.jar', '$1.jar'
+			// Doing: rename '(.*)-[0-9]+\\..*.jar', '$1.jar'
+			// but also add an index if a file name already exists
+			rename { filename ->
+                if (filename ==~ '(.*)\\.jar') {
+                    def name = filename.replaceFirst('(.*)-[0-9]+\\..*.jar', '$1')
+                    def extension = 'jar'
+					filename = "${name}.${extension}"
+                    def index = 1
+                    while (!usedFileNames.add(filename)) {
+                        filename = "${name}_${index}.${extension}"
+                        index++
+                    }
+                }
+				return filename
+			}
             rename '(.*)-[0-9]+\\..*.war', '$1.war'
             duplicatesStrategy = DuplicatesStrategy.EXCLUDE
         }


### PR DESCRIPTION
## Motivation

Originally the issue was raised when using interlok-json and interlok-kinesis (AWS Kinesis), they both depend on some dependencies with the artifactId json-utils (com.bazaarvoice.jolt:json-utils:0.1.5 and software.amazon.awssdk:json-utils:2.17.52) which create a conflict between jar files in the lib directory and one override the other.
But I also found out that there is an issue with annotation.jar (org.jetbrains:annotations:13.0 and software.amazon.awssdk:annotations:2.17.52) but that's a conflict that occur only with interlok-kinesis.

And of course having missing jars means potential NoClassDefFounderror

```gradle
ext {
  interlokVersion = project.findProperty("interlokVersion") ?: "4.3.0B1-RELEASE"

  interlokParentGradle = "https://raw.githubusercontent.com/adaptris/interlok-build-parent/1.8.2/v4/build.gradle"
}

allprojects {
  apply from: "${interlokParentGradle}"
}

dependencies {
  interlokRuntime ("com.adaptris:interlok-json:$interlokVersion") { changing=true }
  interlokRuntime ("com.adaptris:interlok-aws-kinesis:$interlokVersion") { changing=true }
}
```

## Modification

In the build.gradle when making the distribution (the Interlok instance lib dir) if a jar already exists with the same name we add an index and increase it as necessary.

I don't know if it's the best way of doing it but it seems ok as at this point in the gradle build we cannot find the group id anymore. I'm happy to get some better suggestions.

Same dependencies with different versions should have already been handler by gradle so we should not get any issue with that normally.

## Result

No more conflict between jar files meaning no more NoClassDefFounderror

## Testing

Use the above build.gradle content:

```gradle
ext {
  interlokVersion = project.findProperty("interlokVersion") ?: "4.3.0B1-RELEASE"

  interlokParentGradle = "https://raw.githubusercontent.com/adaptris/interlok-build-parent/feature/INTERLOK-3853-Avoid-duplicated-jar-names/v4/build.gradle"
}

allprojects {
  apply from: "${interlokParentGradle}"
}

dependencies {
  interlokRuntime ("com.adaptris:interlok-json:$interlokVersion") { changing=true }
  interlokRuntime ("com.adaptris:interlok-aws-kinesis:$interlokVersion") { changing=true }
}
```

And run `gradle clean assemble`. That should work fine, you should have an interlok install in the build/distribution and the lib dir should have json-utils.jar, json-utils_1.jar, annotations.jar and annotations_1.jar.

