### PR TITLE
INTERLOK-3853 Differentiate between jars and javadocs jars so the javadocs don't get an index

### DIFF
--- a/v3/build.gradle
+++ b/v3/build.gradle
@@ -468,22 +468,30 @@ distributions {
             // Doing: rename '(.*)-[0-9]+\\..*.jar', '$1.jar'
             // but also add an index if a file name already exists
             rename { filename ->
-                if (filename ==~ '(.*)\\.jar') {
-                    def name = filename.replaceFirst('(.*)-[0-9]+\\..*.jar', '$1')
-                    def extension = 'jar'
-                    filename = "${name}.${extension}"
-                    def index = 1
-                    while (!usedFileNames.add(filename)) {
-                        filename = "${name}_${index}.${extension}"
-                        index++
-                    }
-                }
-                return filename
+                return renameJarFile(filename, usedFileNames)
             }
             rename '(.*)-[0-9]+\\..*.war', '$1.war'
             duplicatesStrategy = DuplicatesStrategy.EXCLUDE
         }
     }
+}
+
+def renameJarFile(filename, usedFileNames) {
+    if (filename ==~ '(.*)\\.jar') {
+        def name = filename.replaceFirst('(.*)-[0-9]+\\.(.*).jar', '$1')
+        def extension = 'jar'
+        def isJavadoc = filename ==~ '(.*)-javadoc\\.jar'
+        filename = "${name}.${extension}"
+        def index = 1
+        // At this point jars and javadoc jars can have the same name
+        // so we differentiate them with the boolean 'isJavadoc'
+        while (!usedFileNames.add(filename + " " + isJavadoc)) {
+            filename = "${name}_${index}.${extension}"
+            index++
+        }
+    }
+    
+    return filename
 }
 
 installDist {

--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -482,22 +482,30 @@ distributions {
             // Doing: rename '(.*)-[0-9]+\\..*.jar', '$1.jar'
             // but also add an index if a file name already exists
             rename { filename ->
-                if (filename ==~ '(.*)\\.jar') {
-                    def name = filename.replaceFirst('(.*)-[0-9]+\\..*.jar', '$1')
-                    def extension = 'jar'
-                    filename = "${name}.${extension}"
-                    def index = 1
-                    while (!usedFileNames.add(filename)) {
-                        filename = "${name}_${index}.${extension}"
-                        index++
-                    }
-                }
-                return filename
+                return renameJarFile(filename, usedFileNames)
             }
             rename '(.*)-[0-9]+\\..*.war', '$1.war'
             duplicatesStrategy = DuplicatesStrategy.EXCLUDE
         }
     }
+}
+
+def renameJarFile(filename, usedFileNames) {
+    if (filename ==~ '(.*)\\.jar') {
+        def name = filename.replaceFirst('(.*)-[0-9]+\\.(.*).jar', '$1')
+        def extension = 'jar'
+        def isJavadoc = filename ==~ '(.*)-javadoc\\.jar'
+        filename = "${name}.${extension}"
+        def index = 1
+        // At this point jars and javadoc jars can have the same name
+        // so we differentiate them with the boolean 'isJavadoc'
+        while (!usedFileNames.add(filename + " " + isJavadoc)) {
+            filename = "${name}_${index}.${extension}"
+            index++
+        }
+    }
+    
+    return filename
 }
 
 installDist {


### PR DESCRIPTION
## Motivation

Since the changed made in https://github.com/adaptris/interlok-build-parent/pull/48 when a build.gradle use the interlok-build-parent and also has interlokJavadocs dependencies the javadocs jar names get the index added to them, e.g. interlok-core_1.jar.

It's not a massive issue as it doesn't break anything but it's still not right.

The reason of this is that where we previously made the changes, the code is not aware of the differences between normal jars and javadocs jars. Therefore, in our example because interlok-core.jar has already been added to the usedFileName set when we rename the javadocs jar in the javadocs dir we add the index.

## Modification

- When checking if a jar name has already been used we differentiate normal and javadocs jars by looking at their original name. If the name ends with -javadocs.jar we consider it to be a javadocs jar.
- Extracted the logic to a function.

## PR Checklist

- [x] been self-reviewed.
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader

## Result

The javadocs jars should be named correctly.

## Testing

Use the build.gradle content:

```gradle
ext {
  interlokVersion = project.findProperty("interlokVersion") ?: "4.3.0B1-RELEASE"

  interlokParentGradle = "https://raw.githubusercontent.com/adaptris/interlok-build-parent/feature/INTERLOK-3853-Remove-index-from-javadocs-jar-names/v4/build.gradle"
}

allprojects {
  apply from: "${interlokParentGradle}"
}

dependencies {
  interlokRuntime ("com.adaptris:interlok-json:$interlokVersion") { changing=true }
  interlokRuntime ("com.adaptris:interlok-aws-kinesis:$interlokVersion") { changing=true }

  interlokJavadocs("com.adaptris:interlok-json:$interlokVersion") { changing=true; transitive=false }
  interlokJavadocs("com.adaptris:interlok-aws-kinesis:$interlokVersion") { changing=true; transitive=false }
}
```

And run `gradle clean assemble`. 

That should work fine, you should have an interlok install in the build/distribution and the lib dir should have json-utils.jar, json-utils_1.jar, annotations.jar and annotations_1.jar.
You should also have a directory docs/javadocs with interlok-core.jar, interlok-common.jar, interlok-json.jar and interlok-aws-kinesis.jar

