### PR TITLE
Fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,6 @@ updates:
     directory: "/v3"
     open-pull-requests-limit: 20
     registries:
-      - "public"
       - "interlok"
     schedule:
       interval: "daily"


### PR DESCRIPTION
## Motivation

Dependabot.yml makes a reference to a public repo which isn't defined.


## Modification

Removed it.

## PR Checklist

- [x] been self-reviewed.

## Testing

Check the insights tab -> dependency graph -> dependabot. It should no longer have an error.