### PR TITLE
INTERLOK-3864 Exclude duplicated JARs

### DIFF
--- a/v3/build.gradle
+++ b/v3/build.gradle
@@ -460,14 +460,11 @@ distributions {
                 from(project.configurations.interlokRuntime)
                 from(serviceTesterDist)
                 eachFile {
+                    // this stops ththe same JAR being included with the suffix _1
                     if (!libs.add(it.sourceName)) {
                         it.exclude()
                     }
                 }
-            }
-            into('lib') {
-                from(serviceTesterDist)
-                filesNotMatching(project.configurations.interlokRuntime, null)
             }
             into('webapps') {
                 from(interlokWarDist)

--- a/v3/build.gradle
+++ b/v3/build.gradle
@@ -460,7 +460,8 @@ distributions {
                 from(project.configurations.interlokRuntime)
                 from(serviceTesterDist)
                 eachFile {
-                    // this stops ththe same JAR being included with the suffix _1
+                    // In dev mode, dependencies from serviceTesterDist may conflict
+                    // with interlokRuntime dependencies. This stops the same JAR being included with the suffix _1
                     if (!libs.add(it.sourceName)) {
                         it.exclude()
                     }

--- a/v3/build.gradle
+++ b/v3/build.gradle
@@ -456,8 +456,18 @@ distributions {
                 from(localizeConfig)
             }
             into('lib') {
+                def libs = new HashSet()
                 from(project.configurations.interlokRuntime)
                 from(serviceTesterDist)
+                eachFile {
+                    if (!libs.add(it.sourceName)) {
+                        it.exclude()
+                    }
+                }
+            }
+            into('lib') {
+                from(serviceTesterDist)
+                filesNotMatching(project.configurations.interlokRuntime, null)
             }
             into('webapps') {
                 from(interlokWarDist)
@@ -490,7 +500,7 @@ def renameJarFile(filename, usedFileNames) {
             index++
         }
     }
-    
+
     return filename
 }
 

--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -474,7 +474,8 @@ distributions {
                 from(project.configurations.interlokRuntime)
                 from(serviceTesterDist)
                 eachFile {
-                    // this stops ththe same JAR being included with the suffix _1
+                    // In dev mode, dependencies from serviceTesterDist may conflict
+                    // with interlokRuntime dependencies. This stops the same JAR being included with the suffix _1
                     if (!libs.add(it.sourceName)) {
                         it.exclude()
                     }

--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -474,14 +474,11 @@ distributions {
                 from(project.configurations.interlokRuntime)
                 from(serviceTesterDist)
                 eachFile {
+                    // this stops ththe same JAR being included with the suffix _1
                     if (!libs.add(it.sourceName)) {
                         it.exclude()
                     }
                 }
-            }
-            into('lib') {
-                from(serviceTesterDist)
-                filesNotMatching(project.configurations.interlokRuntime, null)
             }
             into('webapps') {
                 from(interlokWarDist)

--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -470,8 +470,18 @@ distributions {
                 from(localizeConfig)
             }
             into('lib') {
+                def libs = new HashSet()
                 from(project.configurations.interlokRuntime)
                 from(serviceTesterDist)
+                eachFile {
+                    if (!libs.add(it.sourceName)) {
+                        it.exclude()
+                    }
+                }
+            }
+            into('lib') {
+                from(serviceTesterDist)
+                filesNotMatching(project.configurations.interlokRuntime, null)
             }
             into('webapps') {
                 from(interlokWarDist)
@@ -504,7 +514,7 @@ def renameJarFile(filename, usedFileNames) {
             index++
         }
     }
-    
+
     return filename
 }
 


### PR DESCRIPTION
## Motivation

To stop the same JAR being included multiple times; for instance `interlok-common.jar` and `interlok-common_1.jar`

## Modification

A loop that checks each file to see whether it's already being included, and if so, the duplicate gets excluded.

## PR Checklist

- [x] been self-reviewed.

## Result

When using `gradle install` the user doesn't end up with a second copy of almost every JAR with a suffix.

## Testing

Run `gradle install`
