### PR TITLE
Pin base interlok version to be 3.12.0.3 if not explicitly configured.

### DIFF
--- a/v3/build.gradle
+++ b/v3/build.gradle
@@ -19,6 +19,11 @@ ext {
   log4j2Version='2.17.1'
   slf4jVersion='1.7.32'
   interlokVersion = project.findProperty('interlokVersion') ?: '3.12.0-RELEASE'
+  // interlok-core is patched to 3.12.0.3-RELEASE
+  // Check the if statement in the dependencies block.
+  interlokCorePatchVersion = project.findProperty('interlokCorePatchVersion') ?: '3.12.0.3-RELEASE'
+  requiresCorePatchVersion = "3.12.0-RELEASE"
+
   verifyReportConfigCheckAvailable = '3.12-SNAPSHOT'
   interlokUiVersion = project.findProperty('interlokUiVersion') ?: interlokVersion
   interlokSourceConfig = "${projectDir}/src/main/interlok/config"
@@ -59,6 +64,10 @@ ext.buildDetails = [
 
   isIncludeWar: { ->
     return includeWar.equals("true") || buildEnv.equals("dev")
+  },
+
+  requiresCorePatch: { ->
+    return VersionNumber.parse( interlokVersion ) == VersionNumber.parse( requiresCorePatchVersion )
   }
 
 ]
@@ -179,12 +188,21 @@ repositories {
 }
 
 dependencies {
-  interlokRuntime ("com.adaptris:interlok-core:$interlokVersion") { changing= true}
-  interlokRuntime ("com.adaptris:interlok-common:$interlokVersion") { changing= true}
-  interlokRuntime ("com.adaptris:interlok-boot:$interlokVersion") { changing=true }
-  interlokRuntime ("com.adaptris:interlok-logging:$interlokVersion") { changing=true }
-  interlokRuntime ("com.adaptris:interlok-varsub:$interlokVersion") { changing=true }
 
+  // If our interlokVersion is set to anything other than 3.12.0-RELEASE then use that
+  // If it is set to 3.12.0-RELEASE then use 3.12.0.3-RELEASE version of Interlokv3.
+  if (interlokVersion.endsWith("SNAPSHOT") || !buildDetails.requiresCorePatch()) {
+    interlokRuntime ("com.adaptris:interlok-core:$interlokVersion") { changing= true}
+    interlokRuntime ("com.adaptris:interlok-common:$interlokVersion") { changing= true}
+    interlokRuntime ("com.adaptris:interlok-boot:$interlokVersion") { changing=true }
+    interlokRuntime ("com.adaptris:interlok-logging:$interlokVersion") { changing=true }
+  } else {
+    interlokRuntime ("com.adaptris:interlok-core:$interlokCorePatchVersion") { changing= true}
+    interlokRuntime ("com.adaptris:interlok-common:$interlokCorePatchVersion") { changing= true}
+    interlokRuntime ("com.adaptris:interlok-boot:$interlokCorePatchVersion") { changing=true }
+    interlokRuntime ("com.adaptris:interlok-logging:$interlokCorePatchVersion") { changing=true }
+  }
+  interlokRuntime ("com.adaptris:interlok-varsub:$interlokVersion") { changing=true }
   interlokRuntime ("org.slf4j:slf4j-api:$slf4jVersion")
   interlokRuntime ("org.slf4j:jcl-over-slf4j:$slf4jVersion")
   interlokRuntime ("org.slf4j:jul-to-slf4j:$slf4jVersion")
@@ -210,6 +228,7 @@ dependencies {
   interlokVerify files("$interlokTmpConfigDirectory"){
       builtBy 'localizeConfig'
   }
+  // Javadocs aren't affected by interlokCorePatchVersion since they should just be bugfixes.
   interlokJavadocs group: "com.adaptris", name: "interlok-core", version: "$interlokVersion", classifier: "javadoc", changing: true, transitive: false
   interlokJavadocs group: "com.adaptris", name: "interlok-common", version: "$interlokVersion", classifier: "javadoc", changing: true, transitive: false
 


### PR DESCRIPTION
## Motivation

The latest release of Interlok v3 is 3.12.0.3-RELEASE which contains a bunch of bug-fixes for 3.12.0. However, the interlokVersion  variable is still pinned at 3.12.0-RELEASE

What we need to do is to have the following logic change.

- If our interlokVersion is set to anything other than 3.12.0-RELEASE then use that
- If it is set to 3.12.0-RELEASE then use 3.12.0.3-RELEASE version of the artifacts 

## Modification

Added an `if` statement to the dependencies block that manages to 

## PR Checklist

- [x] been self-reviewed.

## Result

If `interlokVersion` is set to be 3.12.0-RELEASE then people get the correct version of interlok-core/interlok-boot etc since those artifacts all belong in the github interlok project.
If interlokVersion is set to anything else (e.g. 3.11.0-RELEASE) then they are pinned at that version.

## Testing

- build.gradle. This includes a couple of optional components to make sure that that pinning doesn't affect optional components.

```
ext {
  interlokParentGradle = "https://raw.githubusercontent.com/adaptris/interlok-build-parent/interlok-core-at-3.12.0.3/v3/build.gradle"
}

allprojects {
  apply from: "${interlokParentGradle}"
}

dependencies {
  interlokRuntime ("com.adaptris:interlok-json:$interlokVersion") { changing=true }
  interlokRuntime ("com.adaptris:interlok-apache-http:$interlokVersion") { changing=true }
}
```

- Explicitly setting interlokVersion to be 3.12.0-RELEASE gives you 

```console
$ gradle -PinterlokVersion=3.12.0-RELEASE interlokVersionReport

> Task :interlokVersionReport
TRACE [main] [c.a.c.m.BootstrapProperties.createProperties()] [{}] Properties resource is [bootstrap.properties]
Bootstrap of Interlok 3.12.0.3-RELEASE(2021-12-21:support/3.12.x) complete
Version Information
  Base Interlok: 3.12.0.3-RELEASE(2021-12-21:support/3.12.x)
  Interlok Annotation Support: 3.12.0.3-RELEASE(2021-12-21:support/3.12.x)
  Interlok Bootstrap: 3.12.0.3-RELEASE(2021-12-21:support/3.12.x)
  Interlok Common Classes: 3.12.0.3-RELEASE(2021-12-21:support/3.12.x)
  Interlok Config Pre-Processor: variable substitution support: 3.12.0-RELEASE(2021-01-25:11:46:35 GMT)
  Interlok Logging: 3.12.0.3-RELEASE(2021-12-21:support/3.12.x)
  Interlok/Apache HTTP: 3.12.0-RELEASE(2021-01-25:11:46:00 GMT)
  Interlok/JSON: 3.12.0-RELEASE(2021-01-25:11:47:22 GMT)
```

- Setting interlokVersion to be 3.11 gives you 

```console
$ gradle -PinterlokVersion=3.11.0-RELEASE interlokVersionReport

> Task :interlokVersionReport
TRACE [main] [c.a.c.m.BootstrapProperties.createProperties()] [{}] Properties resource is [bootstrap.properties]
Bootstrap of Interlok 3.11.0-RELEASE(2020-09-21:16:37:47 BST) complete
Version Information
  Base Interlok: 3.11.0-RELEASE(2020-09-21:16:37:47 BST)
  Interlok Annotation Support: 3.11.0-RELEASE(2020-09-21:16:37:03 BST)
  Interlok Bootstrap: 3.11.0-RELEASE(2020-09-21:16:37:06 BST)
  Interlok Common Classes: 3.11.0-RELEASE(2020-09-21:16:37:11 BST)
  Interlok Config Pre-Processor: variable substitution support: 3.11.0-RELEASE(2020-09-21:16:47:50 BST)
  Interlok Logging: 3.11.0-RELEASE(2020-09-21:16:44:31 BST)
  Interlok/Apache HTTP: 3.11.0-RELEASE(2020-09-21:16:47:40 BST)
  Interlok/JSON: 3.11.0-RELEASE(2020-09-21:16:48:55 BST)
```
