### PR TITLE
Pass in system properties to JavaExec / allow 'latest.integration' to be used as a version.

### DIFF
--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -68,6 +68,9 @@ ext.buildDetails = [
   },
 
   hasServiceTesterPatch: { ->
+    if (interlokVersion.startsWith("latest.")) {
+      return false
+    }
     return VersionNumber.parse( interlokVersion ) == VersionNumber.parse( requiresServiceTesterPatch )
   }
 
@@ -76,6 +79,9 @@ ext.buildDetails = [
 ext.verifyReport = [
 
   verifyViaConfigCheck: { ->
+    if (interlokVersion.startsWith("latest.")) {
+      return true
+    }
     return VersionNumber.parse( interlokVersion ) >= VersionNumber.parse( verifyReportConfigCheckAvailable )
   },
 
@@ -279,6 +285,7 @@ def interlokVersionReport = tasks.register("interlokVersionReport", JavaExec) {
     workingDir = new File("${buildDir}/tmp")
     classpath = files(verifyLauncherJar.archivePath)
 
+    systemProperties System.properties
     mainClass = 'com.adaptris.core.management.SimpleBootstrap'
     args "-version"
 }
@@ -305,6 +312,8 @@ def interlokVerifyLog4j= tasks.register("interlokVerifyLog4j", JavaExec) {
   args "-configtest"
   environment loadPropertiesFromFile(interlokVerifyEnvironmentPropertiesFile)
   environment project.hasProperty('interlokVerifyEnvironmentProperties') ? project.getProperty('interlokVerifyEnvironmentProperties') : [:]
+  // Pass through system properties.
+  systemProperties System.properties
   systemProperties project.hasProperty('interlokVerifySystemProperties') ? project.getProperty('interlokVerifySystemProperties') : [:]
   systemProperties interlokVerifyLicenseProperties
   systemProperty "interlok.logging.url", verifyLog4j
@@ -336,6 +345,8 @@ def interlokVerifyConfigCheck= tasks.register("interlokVerifyConfigCheck", JavaE
   args "-configtest"
   environment loadPropertiesFromFile(interlokVerifyEnvironmentPropertiesFile)
   environment project.hasProperty('interlokVerifyEnvironmentProperties') ? project.getProperty('interlokVerifyEnvironmentProperties') : [:]
+  // Pass through system properties.
+  systemProperties System.properties
   systemProperties project.hasProperty('interlokVerifySystemProperties') ? project.getProperty('interlokVerifySystemProperties') : [:]
   systemProperties interlokVerifyLicenseProperties
   systemProperty "interlok.verify.warning.filename", interlokVerifyTextReport


### PR DESCRIPTION
## Motivation

This fixes https://github.com/adaptris/interlok-build-parent/issues/44

Also, if _latest.release_ or _latest.integration_ is specified as the `interlokVersion` then the __interlokVerify__ task assumes that it needs to parse the log4j output to determine errors.  This is because the VersionNumber comparision assumes that it will always be numeric.

## Modification

- Pass in system properties to all javaExec tasks.
- Add a fix for verifyVia / hasServiceTesterPatch so that they cope with "latest.integration" and "latest.version" for interlokVersion when doing the Version Number comparisons.

## PR Checklist

- [x] been self-reviewed.

## Result

- No need to specify JAVA_TOOL_OPTIONS as a work-around if you're using graalvm to replace nashorn
- latest.release / latest.integration now means that we do the interlokVerify via the `interlokVerifyConfigCheck` task rather than `interlokVerifyLog4j`

## Testing

Use the attached zip file : [parent-sysprops.zip](https://github.com/adaptris/interlok-build-parent/files/7829353/parent-sysprops.zip) which refers to the v4/build.gradle in the branch and sets the interlokVersion to be `latest.integration` which equates to the latest _SNAPSHOT_

```console
$ unset JAVA_TOOL_OPTIONS
$ gradle check
To honour the JVM settings for this build a single-use Daemon process will be forked. See https://docs.gradle.org/7.1/userguide/gradle_daemon.html#sec:disabling_the_daemon.
Daemon will be stopped at the end of the build
> Task :checkJavaVersion
> Task :getServiceTestLog4j2
> Task :serviceTesterLauncherJar
> Task :interlokServiceTest SKIPPED
> Task :interlokServiceTestReport SKIPPED
> Task :localizeConfig
> Task :verifyLauncherJar

> Task :interlokVerifyConfigCheck
[To redirect Truffle log output to a file use one of the following options:
* '--log.file=<path>' if the option is passed using a guest language launcher.
* '-Dpolyglot.log.file=<path>' if the option is passed using the host Java launcher.
* Configure logging using the polyglot embedding API.]
[engine] WARNING: The polyglot context is using an implementation that does not support runtime compilation.
The guest application code will therefore be executed in interpreted mode only.
.... With a lot of stack traces, but the build will succeed in the end.
```

If you pass in the correct system properties then the stack traces are removed.
- Because we have specified latest.integration as the version we can see that interlokVerifyConfigLog4j is `SKIPPED`. It would not if this same build.gradle targetted the main branch build-parent.

```console
$ unset JAVA_TOOL_OPTIONS
$ gradle -Dpolyglot.js.nashorn-compat=true -Dpolyglot.engine.WarnInterpreterOnly=false check
To honour the JVM settings for this build a single-use Daemon process will be forked. See https://docs.gradle.org/7.1/userguide/gradle_daemon.html#sec:disabling_the_daemon.
Daemon will be stopped at the end of the build
> Task :checkJavaVersion
> Task :getServiceTestLog4j2 UP-TO-DATE
> Task :serviceTesterLauncherJar UP-TO-DATE
> Task :interlokServiceTest SKIPPED
> Task :interlokServiceTestReport SKIPPED
> Task :localizeConfig UP-TO-DATE
> Task :verifyLauncherJar UP-TO-DATE

> Task :interlokVerifyConfigCheck
TRACE [main] [c.a.c.m.BootstrapProperties] Properties resource is [bootstrap.properties]
Bootstrap of Interlok 4.4-SNAPSHOT(2022-01-07:03:24:31 GMT) complete
TRACE [main] [c.a.c.m.p.PropertyResolver] Parsing PropertyResolver URL [jar:file:/C:%5CUsers%5CLewin.Chan%5C.gradle%5Ccaches%5Cmodules-2%5Cfiles-2.1%5Ccom.adaptris%5Cinterlok-core%5C4.4-SNAPSHOT%5Cc6d26504f40e521d83ce9fe9f8b9610c9190ef45%5Cinterlok-core-4.4-SNAPSHOT.jar!/META-INF/com/adaptris/core/management/properties/resolver]
TRACE [main] [c.a.c.m.p.PropertyResolver] Registered Decoders : {password=com.adaptris.core.management.properties.PasswordDecoder}
TRACE [main] [c.a.c.m.BootstrapProperties] Adding org.jboss.logging.provider=slf4j to system properties
TRACE [main] [c.a.c.m.BootstrapProperties] Adding org.jruby.embed.localcontext.scope=threadsafe to system properties
TRACE [main] [c.a.c.m.BootstrapProperties] Attempting Logging reconfiguration using file://localhost/./config/log4j2.xml
2022-01-07 14:31:37,257 main WARN Could not locate file file:/C:/storage/work/runtime/interlok/parent-sysprops/./config/log4j2.xml
2022-01-07 14:31:37,257 main WARN Could not locate file file:/C:/storage/work/runtime/interlok/parent-sysprops/./config/log4j2.xml
TRACE [main] [c.a.c.c.DefaultPreProcessorLoader] Loading pre-processor: xinclude
WARN  [main] [c.a.c.c.DefaultPreProcessorLoader] Unable to find pre-processor with name: [xinclude].  Ignoring.
TRACE [main] [c.a.c.c.DefaultPreProcessorLoader] Loading pre-processor: com.adaptris.core.varsub.VariableSubstitutionPreProcessor
WARN  [main] [c.a.c.v.VariableSubstitutionPreProcessor] Configuration variable substitution will have no effect; no properties file specified against key (variable-substitution.properties.url)
TRACE [main] [VariableSubstitution] Performing configuration variable substitution
WARN  [main] [c.a.c.Adapter] [Adapter(MyInterlokInstance)] has a MessageErrorHandler with no behaviour; messages may be discarded upon exception
DEBUG [main] [c.a.c.Adapter] FailedMessageRetrier []

Configuration loading test:
Passed.

Classpath duplication check:
Passed.

javax.validation checks:
Passed.

Deprecated checks:
Passed.

Shared connection check:
Passed.

Shared service check:
Passed.

Nashorn Scripting Engine check:
Passed.

Config check only; terminating

> Task :interlokVerifyLog4j SKIPPED
> Task :interlokVerify
> Task :interlokVerifyReport

> Task :interlokVersionReport
TRACE [main] [c.a.c.m.BootstrapProperties] Properties resource is [bootstrap.properties]
Bootstrap of Interlok 4.4-SNAPSHOT(2022-01-07:03:24:31 GMT) complete
Version Information
  Interlok Config/variable substitutions: 4.4-SNAPSHOT(2022-01-07:03:38:36 GMT)
  Interlok Core/Annotations: 4.4-SNAPSHOT(2022-01-07:03:24:31 GMT)
  Interlok Core/Base: 4.4-SNAPSHOT(2022-01-07:03:24:31 GMT)
  Interlok Core/Bootstrap: 4.4-SNAPSHOT(2022-01-07:03:24:31 GMT)
  Interlok Core/Common: 4.4-SNAPSHOT(2022-01-07:03:24:31 GMT)
  Interlok Core/Logging: 4.4-SNAPSHOT(2022-01-07:03:24:32 GMT)
  Interlok HTTP/Apache HTTP(4): 4.4-SNAPSHOT(2022-01-07:03:40:09 GMT)
  Interlok Transform/CSV: 4.4-SNAPSHOT(2022-01-07:03:41:40 GMT)
  Interlok Transform/JSON: 4.4-SNAPSHOT(2022-01-07:03:39:45 GMT)
  Interlok Transform/STaX: 4.4-SNAPSHOT(2022-01-07:03:38:23 GMT)

> Task :compileJava NO-SOURCE
> Task :processResources NO-SOURCE
> Task :classes UP-TO-DATE
> Task :compileTestJava NO-SOURCE
> Task :processTestResources NO-SOURCE
> Task :testClasses UP-TO-DATE
> Task :test NO-SOURCE
> Task :check

BUILD SUCCESSFUL in 17s
9 actionable tasks: 5 executed, 4 up-to-date
```
