### PR TITLE
Force log4j configuration when running during gradle build

### DIFF
--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -337,6 +337,9 @@ def interlokVerifyConfigCheck= tasks.register("interlokVerifyConfigCheck", JavaE
     verifyReport.verifyViaConfigCheck()
   }
   doFirst {
+    if(new File("$interlokTmpConfigDirectory/log4j2.xml").exists()) {
+      ant.move file: "$interlokTmpConfigDirectory/log4j2.xml", tofile: "$interlokTmpConfigDirectory/log4j2.xml.bk"
+    }
     verifyReport.init()
   }
   workingDir = new File("${buildDir}/tmp")
@@ -353,6 +356,11 @@ def interlokVerifyConfigCheck= tasks.register("interlokVerifyConfigCheck", JavaE
   systemProperty "interlok.verify.warning.category", interlokVerifyCategory
   systemProperty "interlok.verify.warning.level", interlokVerifyLevel
   systemProperty "interlok.logging.url", verifyLog4j
+  doLast {
+    if(new File("$interlokTmpConfigDirectory/log4j2.xml.bk").exists()) {
+      ant.move file: "$interlokTmpConfigDirectory/log4j2.xml.bk", tofile: "$interlokTmpConfigDirectory/log4j2.xml"
+    }
+  }
 }
 
 

--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -352,6 +352,7 @@ def interlokVerifyConfigCheck= tasks.register("interlokVerifyConfigCheck", JavaE
   systemProperty "interlok.verify.warning.filename", interlokVerifyTextReport
   systemProperty "interlok.verify.warning.category", interlokVerifyCategory
   systemProperty "interlok.verify.warning.level", interlokVerifyLevel
+  systemProperty "interlok.logging.url", verifyLog4j
 }
 
 

--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -282,12 +282,23 @@ tasks.register("verifyLauncherJar", Jar) {
 def interlokVersionReport = tasks.register("interlokVersionReport", JavaExec) {
     group = 'Verification'
     description = 'Show Interlok versions using -version'
+    doFirst {
+      if(new File("$interlokTmpConfigDirectory/log4j2.xml").exists()) {
+        ant.move file: "$interlokTmpConfigDirectory/log4j2.xml", tofile: "$interlokTmpConfigDirectory/log4j2.xml.bk"
+      }
+    }
     workingDir = new File("${buildDir}/tmp")
     classpath = files(verifyLauncherJar.archivePath)
-
     systemProperties System.properties
+    systemProperty "interlok.logging.url", verifyLog4j
+
     mainClass = 'com.adaptris.core.management.SimpleBootstrap'
     args "-version"
+    doLast {
+      if(new File("$interlokTmpConfigDirectory/log4j2.xml.bk").exists()) {
+        ant.move file: "$interlokTmpConfigDirectory/log4j2.xml.bk", tofile: "$interlokTmpConfigDirectory/log4j2.xml"
+      }
+    }
 }
 
 interlokVersionReport.configure {


### PR DESCRIPTION
## Motivation

If you have a log4j that references "non-existent" locations then you can get exceptions during `./gradlew check`

c.f. Your log4j2 is something like this

```
<Configuration status="warn" monitorInterval="60" shutdownHook="disable">
  <Appenders>
    <RollingFile name="LOGFILE" fileName="logs/interlok.log" filePattern="logs/interlok.log.%i" ignoreExceptions="true" createOnDemand="true">
    </RollingFile>
  <Loggers>

    <Root level="TRACE">
      <AppenderRef ref="LOGFILE"/>
    </Root>
  </Loggers>
</Configuration>
```

Then you get lots of logging of errors (sometimes even gradle fails if log4j2 fails to initialise (happens consistently with 2.17 now) 

```
Picked up JAVA_TOOL_OPTIONS: -Dpolyglot.js.nashorn-compat=true -Dpolyglot.engine.WarnInterpreterOnly=false
2022-01-13 20:38:15,324 Log4j2-AsyncAppenderEventDispatcher-1-Async ERROR Unable to write to stream logs/interlok.log for appender LOGFILE org.apache.logging.log4j.core.appender.AppenderLoggingException: Error writing to stream logs/interlok.log

etc etc
```

Note: You are able to work around this by having a `log4j2.xml.dev` if you're running on your local machine, but if you're running on the target deployment machine in the "wrong directory" and you're using a relative fileName, then you still get the errors.

## Modification

Since verifyLog4j already exists, then we can force logging using the sytem property `interlok.logging.url` whenever we execute interlok with "configCheck" and "version".

Modify the tasks interlokVerifyConfigCheck and interlokVersionReport such that

- renames log4j2.xml -> log4j2.xml.bk
- sets `interlok.logging.url` to be the right thing
- executes the task
- restores log4j2.xml


## PR Checklist

- [x] been self-reviewed.

## Result

Cut down logging from configCheck which is probably a good thing anyway and no stack trace error message from log4j if you are using a log4j that is correct for "production/qa" but not correct for your local environment.

## Testing

You can just use https://github.com/quotidian-ennui/interlok-speedtest-elastic and run `gradle check`.

