### PR TITLE
Make interlokServiceTest operations property driven

### DIFF
--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -465,7 +465,7 @@ task interlokServiceTestReport {
       )
 
       ant.junitreport(todir: interlokServiceTestReportDir) {
-        fileset(dir: interlokServiceTestOutput, includes: 'TEST-*.xml')
+        fileset(dir: interlokServiceTestOutput, includes: '**/TEST-*.xml')
         report(todir: interlokServiceTestReportDir, format: "frames")
       }
     }

--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -33,7 +33,13 @@ ext {
   interlokTmpWarDirectory = "${buildDir}/tmp/war"
   interlokTmpDocsDirectory = "${buildDir}/tmp/docs"
   interlokTmpServiceTestLog4j = "${buildDir}/tmp/serviceTestLog4j/log4j2.xml"
+
   interlokDistDirectory = project.findProperty('interlokDistDirectory') ?: "${buildDir}/distribution"
+
+  interlokServiceTestOutput = project.findProperty('interlokServiceTestOutput') ?: "${buildDir}/reports/unit"
+  interlokServiceTestReportDir = project.findProperty('interlokServiceTestReportDir') ?: "${buildDir}/reports/html"
+  interlokServiceTestDefinition = project.findProperty('interlokServiceTestDefinition') ?: "$projectDir/src/test/interlok/service-test.xml"
+
   buildEnv = project.findProperty('buildEnv') ?: 'NoBuildEnv'
   includeWar = project.findProperty('includeWar') ?: 'false'
   additionalTemplatedConfiguration = project.findProperty('additionalTemplatedConfiguration') ?: []
@@ -429,14 +435,14 @@ def interlokServiceTest = tasks.register("interlokServiceTest", JavaExec) {
     group = 'Test'
     description = 'Execute Interlok service tests'
     onlyIf {
-      new File("$projectDir/src/test/interlok/service-test.xml").exists()
+      new File(interlokServiceTestDefinition).exists()
     }
     mainClass = 'com.adaptris.tester.runners.TestExecutor'
     classpath = files(serviceTesterLauncherJar.archivePath)
     args "-serviceTest"
-    args "$projectDir/src/test/interlok/service-test.xml"
+    args interlokServiceTestDefinition
     args "-serviceTestOutput"
-    args "$buildDir/reports/unit/"
+    args interlokServiceTestOutput
 }
 
 interlokServiceTest.configure {
@@ -451,16 +457,16 @@ task interlokServiceTestReport {
       interlokServiceTest.get().didWork
     }
     doLast {
-      mkdir "$buildDir/reports/html"
+      mkdir interlokServiceTestReportDir
       ant.taskdef(
         name: 'junitreport',
         classname: 'org.apache.tools.ant.taskdefs.optional.junit.XMLResultAggregator',
         classpath: configurations.antJunit.asPath
       )
 
-      ant.junitreport(todir: "$buildDir/reports/html") {
-        fileset(dir: "$buildDir/reports/unit", includes: 'TEST-*.xml')
-        report(todir: "$buildDir/reports/html", format: "frames")
+      ant.junitreport(todir: interlokServiceTestReportDir) {
+        fileset(dir: interlokServiceTestOutput, includes: 'TEST-*.xml')
+        report(todir: interlokServiceTestReportDir, format: "frames")
       }
     }
 }


### PR DESCRIPTION
## Motivation

Don't hard-code the service-test.xml & reporting test dirs and make them property driven.  Since the HTML report is just `ant junitreport` we can now make gradle write its junitXML files to the same-ish location.

## Modification

- service-test definition file is now a property (default is `./src/test/interlok/service-test.xml`)
- service-test output dir is now a property (default is `./build/reports/unit`)
- html reports is now a property (default is `./build/reports/html`)

## PR Checklist

- [x] been self-reviewed.

## Result

No material change for the user.

## Testing

You can do `./gradlew -PinterlokServiceTestOutput=./build/my-test-output check` to change the location of the `TEST-*.xml` files.

Realistically, what you're likely to do is this (this is useful to get an aggregated view of both the unit tests and service-tester tests) and to view `./build/reports/html/index.html` in your browser...

```
test {
  reports {
    // Use a sub-dir since gradle will empty the directory 
    junitXml.outputLocation.set(layout.buildDirectory.dir("$interlokServiceTestOutput/java"))
  }
}
// Suggest that interlokServiceTestReport runs after running the unit tests.
interlokServiceTestReport.shouldRunAfter test
```

