### PR TITLE
INTERLOK-3885 #comment Upgrade interlok-verify-report

### DIFF
--- a/v3/build.gradle
+++ b/v3/build.gradle
@@ -232,7 +232,7 @@ dependencies {
   interlokJavadocs group: "com.adaptris", name: "interlok-core", version: "$interlokVersion", classifier: "javadoc", changing: true, transitive: false
   interlokJavadocs group: "com.adaptris", name: "interlok-common", version: "$interlokVersion", classifier: "javadoc", changing: true, transitive: false
 
-  interlokVerifyReport("com.adaptris.labs:interlok-verify-report:2.1.0")
+  interlokVerifyReport("com.adaptris.interlok-verify-report:2.2.0")
 
   antJunit ("org.apache.ant:ant-junit:1.10.12")
 }
@@ -365,7 +365,7 @@ def interlokVerifyReport = tasks.register("interlokVerifyReport", JavaExec) {
     // (interlokVerifyConfigCheck.get().didWork || interlokVerifyLog4j.get().didWork) && new File(interlokVerifyTextReport).exists()
     interlokVerify.get().didWork && new File(interlokVerifyTextReport).exists()
   }
-  mainClass = 'com.adaptris.labs.verify.CreateVerifyReport'
+  mainClass = 'com.adaptris.verify.CreateVerifyReport'
   classpath = configurations.interlokVerifyReport
   args "--reportFile"
   args interlokVerifyTextReport

--- a/v3/build.gradle
+++ b/v3/build.gradle
@@ -232,7 +232,7 @@ dependencies {
   interlokJavadocs group: "com.adaptris", name: "interlok-core", version: "$interlokVersion", classifier: "javadoc", changing: true, transitive: false
   interlokJavadocs group: "com.adaptris", name: "interlok-common", version: "$interlokVersion", classifier: "javadoc", changing: true, transitive: false
 
-  interlokVerifyReport("com.adaptris.interlok-verify-report:2.2.0")
+  interlokVerifyReport("com.adaptris:interlok-verify-report:2.2.0")
 
   antJunit ("org.apache.ant:ant-junit:1.10.12")
 }

--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -239,7 +239,7 @@ dependencies {
   interlokJavadocs group: "com.adaptris", name: "interlok-core", version: "$interlokVersion", classifier: "javadoc", changing: true, transitive: false
   interlokJavadocs group: "com.adaptris", name: "interlok-common", version: "$interlokVersion", classifier: "javadoc", changing: true, transitive: false
 
-  interlokVerifyReport("com.adaptris.interlok-verify-report:3.0.0")
+  interlokVerifyReport("com.adaptris:interlok-verify-report:3.0.0")
 
   antJunit ("org.apache.ant:ant-junit:1.10.12")
 }

--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -239,7 +239,7 @@ dependencies {
   interlokJavadocs group: "com.adaptris", name: "interlok-core", version: "$interlokVersion", classifier: "javadoc", changing: true, transitive: false
   interlokJavadocs group: "com.adaptris", name: "interlok-common", version: "$interlokVersion", classifier: "javadoc", changing: true, transitive: false
 
-  interlokVerifyReport("com.adaptris.labs:interlok-verify-report:2.1.0")
+  interlokVerifyReport("com.adaptris.interlok-verify-report:3.0.0")
 
   antJunit ("org.apache.ant:ant-junit:1.10.12")
 }
@@ -397,7 +397,7 @@ def interlokVerifyReport = tasks.register("interlokVerifyReport", JavaExec) {
     // (interlokVerifyConfigCheck.get().didWork || interlokVerifyLog4j.get().didWork) && new File(interlokVerifyTextReport).exists()
     interlokVerify.get().didWork && new File(interlokVerifyTextReport).exists()
   }
-  mainClass = 'com.adaptris.labs.verify.CreateVerifyReport'
+  mainClass = 'com.adaptris.verify.CreateVerifyReport'
   classpath = configurations.interlokVerifyReport
   args "--reportFile"
   args interlokVerifyTextReport


### PR DESCRIPTION
## Motivation

Older version of interlok-verify-report depends on and older jackson version with vulnerabilities

## Modification

Upgrade to the latest interlok-verify-report
- v3 to 2.2.0
- v4 to 3.0.0 (java 11)

## PR Checklist

- [x] been self-reviewed.

## Result

Users should not get report of vulnerabilities in the dependency tree

## Testing

Run `gradle clean build` a report.json file should be created and interlok-verify-report should work as before