### PR TITLE
Allow interlokVersion to diverge from other required versions

### DIFF
--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -18,14 +18,30 @@ ext {
   nexusBaseUrl  = 'https://nexus.adaptris.net'
   log4j2Version='2.17.2'
   slf4jVersion='1.7.36'
-  // Make interlokServiceTester an explicit version
-  // If interlokVersion == SNAPSHOT then server-tester follows snapshot, otherwise it should
-  // be pinned to it's own release.
+  // Make semi-required optional components have an explicit version
   interlokVersion = project.findProperty('interlokVersion') ?: '4.4.0-RELEASE'
-  interlokServiceTesterVersion = project.findProperty('interlokServiceTesterVersion') ?: '4.2.1-RELEASE'
+  interlokHelperVersion = project.findProperty('interlokVersion') ?: interlokVersion
+  interlokServiceTesterVersion = project.findProperty('interlokServiceTesterVersion') ?: interlokVersion
   interlokUiVersion = project.findProperty('interlokUiVersion') ?: interlokVersion
+
+  // Handles the situation where interlokVersion diverges from baseline versions of the other jars.
+  // e.g. 4.4.1-RELEASE interlok doesn't have a corresponding build of 4.4.1-varsub or 4.4.1-service-tester.
+  // key= interlokVersion
+  // value= the required var-sub version
+  interlokPatchVersionMap = [
+    "4.4.1-RELEASE" : "4.4.0-RELEASE"
+  ]
+  // key= interlokVersion
+  // value= the required service-tester-version
+  interlokServiceTesterPatchVersionMap = [
+    "4.2.0-RELEASE" : "4.2.1-RELEASE",
+    "4.4.1-RELEASE" : "4.4.0-RELEASE"
+  ]
+  interlokUiPatchVersionMap = [
+    "4.4.1-RELEASE" : "4.4.0-RELEASE"
+  ]
+
   verifyReportConfigCheckAvailable = '3.12-SNAPSHOT'
-  requiresServiceTesterPatch = "4.2.0-RELEASE"
 
   interlokSourceConfig = "${projectDir}/src/main/interlok/config"
   interlokTmpConfigDirectory = "${buildDir}/tmp/config"
@@ -71,15 +87,44 @@ ext.buildDetails = [
 
   isIncludeWar: { ->
     return includeWar.equals("true") || buildEnv.equals("dev")
-  },
-
-  hasServiceTesterPatch: { ->
-    if (interlokVersion.startsWith("latest.")) {
-      return false
-    }
-    return VersionNumber.parse( interlokVersion ) == VersionNumber.parse( requiresServiceTesterPatch )
   }
 
+]
+
+ext.interlokPatch = [
+  serviceTesterVersion: { ->
+    def computedVersion = interlokServiceTesterVersion
+    if (interlokServiceTesterVersion.equals(interlokVersion)) {
+      interlokServiceTesterPatchVersionMap.each { iv, pv ->
+        if (interlokVersion.equals(iv)) {
+          computedVersion=pv
+        }
+      }
+    }
+    return computedVersion
+  },
+  helperVersion: { ->
+    def computedVersion = interlokHelperVersion
+    if (interlokHelperVersion.equals(interlokVersion)) {
+      interlokPatchVersionMap.each { iv, pv ->
+        if (interlokVersion.equals(iv)) {
+          computedVersion= pv
+        }
+      }
+    }
+    return computedVersion
+  },
+  uiVersion: { ->
+    def computedVersion = interlokUiVersion
+    if (interlokUiVersion.equals(interlokVersion)) {
+      interlokUiPatchVersionMap.each { iv, pv ->
+        if (interlokVersion.equals(iv)) {
+          computedVersion= pv
+        }
+      }
+    }
+    return computedVersion
+  }
 ]
 
 ext.verifyReport = [
@@ -148,31 +193,31 @@ distTar.enabled=false
 distZip.enabled=false
 
 configurations {
-    interlokRuntime{}
-    interlokTestRuntime{}
-    interlokJavadocs{}
-    interlokVerify{}
-    interlokVerifyReport{}
-    interlokWar{}
-    antJunit{}
-    all*.exclude group: 'c3p0'
-    all*.exclude group: 'commons-logging'
-    all*.exclude group: 'javamail'
-    all*.exclude group: 'javax.mail', module: 'mail'
-    all*.exclude group: 'org.glassfish.hk2.external'
-    all*.exclude group: 'xalan', module: 'xalan'
-    all*.exclude group: 'net.sf.saxon', module: 'saxon'
-    // Exclude because com.fasterxml.woodstox:woodstox-core should take precedence
-    // however, stax2-api still lives on in the org.codehaus.woodstox group
-    all*.exclude group: 'org.codehaus.woodstox', module: 'woodstox-core-asl'
-    all*.exclude group: 'org.eclipse.jetty.orbit', module: 'javax.mail.glassfish'
-    all*.exclude group: 'javax.el', module: 'javax.el-api'
-    all*.exclude group: 'org.hibernate', module: 'hibernate-validator'
-    // INTERLOK-3197 exclude old javax.mail
-    all*.exclude group: 'com.sun.mail', module: 'javax.mail'
-    all*.exclude group: 'javax.validation', module: 'validation-api'
-    all*.exclude group: 'javax.activation', module: 'activation'
-    all*.exclude group: 'javax.activation', module: 'javax.activation-api'
+  interlokRuntime{}
+  interlokTestRuntime.extendsFrom interlokRuntime
+  interlokJavadocs{}
+  interlokVerify{}
+  interlokVerifyReport{}
+  interlokWar{}
+  antJunit{}
+  all*.exclude group: 'c3p0'
+  all*.exclude group: 'commons-logging'
+  all*.exclude group: 'javamail'
+  all*.exclude group: 'javax.mail', module: 'mail'
+  all*.exclude group: 'org.glassfish.hk2.external'
+  all*.exclude group: 'xalan', module: 'xalan'
+  all*.exclude group: 'net.sf.saxon', module: 'saxon'
+  // Exclude because com.fasterxml.woodstox:woodstox-core should take precedence
+  // however, stax2-api still lives on in the org.codehaus.woodstox group
+  all*.exclude group: 'org.codehaus.woodstox', module: 'woodstox-core-asl'
+  all*.exclude group: 'org.eclipse.jetty.orbit', module: 'javax.mail.glassfish'
+  all*.exclude group: 'javax.el', module: 'javax.el-api'
+  all*.exclude group: 'org.hibernate', module: 'hibernate-validator'
+  // INTERLOK-3197 exclude old javax.mail
+  all*.exclude group: 'com.sun.mail', module: 'javax.mail'
+  all*.exclude group: 'javax.validation', module: 'validation-api'
+  all*.exclude group: 'javax.activation', module: 'activation'
+  all*.exclude group: 'javax.activation', module: 'javax.activation-api'
 }
 
 
@@ -205,7 +250,7 @@ dependencies {
   interlokRuntime ("com.adaptris:interlok-common:$interlokVersion") { changing= true}
   interlokRuntime ("com.adaptris:interlok-boot:$interlokVersion") { changing=true }
   interlokRuntime ("com.adaptris:interlok-logging:$interlokVersion") { changing=true }
-  interlokRuntime ("com.adaptris:interlok-varsub:$interlokVersion") { changing=true }
+  interlokRuntime group: "com.adaptris", name: "interlok-varsub", version: interlokPatch.helperVersion(), changing: true
 
   interlokRuntime ("org.slf4j:slf4j-api:$slf4jVersion")
   interlokRuntime ("org.slf4j:jcl-over-slf4j:$slf4jVersion")
@@ -220,18 +265,8 @@ dependencies {
   // CVE-2021-39139 (4.2-SNAPSHOT is already at 1.4.18)
   interlokRuntime ("com.thoughtworks.xstream:xstream:1.4.19")
 
-  // The hasServiceTesterPatch() condition should become redundant for 4.3.0-RELEASE
-  // since dependabot should auto-upgrade to 4.3.0-RELEASE for service tester as well.
-  // Expectation is 4.1.0-RELEASE -> 4.1.0 for both interlok-core & service-tester
-  // 4.2.0-RELEASE -> interlok-core, service-tester=4.2.1-RELEASE
-  // 4.3-SNAPSHOT -> interlok-core + service-tester == 4.3-SNAPSHOT
-  if (interlokVersion.endsWith("SNAPSHOT") || !buildDetails.hasServiceTesterPatch()) {
-    interlokTestRuntime ("com.adaptris:interlok-service-tester:$interlokVersion") { changing=true }
-  } else {
-    interlokTestRuntime ("com.adaptris:interlok-service-tester:$interlokServiceTesterVersion") { changing=true }
-  }
-
-  interlokWar  ("com.adaptris.ui:interlok:$interlokUiVersion@war") {changing=true}
+  interlokTestRuntime group: "com.adaptris", name: "interlok-service-tester", version: interlokPatch.serviceTesterVersion(), changing: true
+  interlokWar group: "com.adaptris.ui", name: "interlok", version: interlokPatch.uiVersion(), changing: true, ext: "war"
 
   interlokVerify files("$interlokTmpConfigDirectory"){
       builtBy 'localizeConfig'
@@ -421,7 +456,7 @@ interlokVerifyLog4j.configure {
 tasks.register("serviceTesterLauncherJar", Jar) {
     appendix = "service-tester-launcher"
     ext.serviceTesterClasspath = { ->
-      def testerLibs = [configurations.interlokRuntime.collect { asFileUrl(it.getCanonicalPath()) }.join(' '),
+      def testerLibs = [
               configurations.interlokTestRuntime.collect { asFileUrl(it.getCanonicalPath()) }.join(' '),
               asFileUrl(new File(interlokTmpServiceTestLog4j).getParentFile().getCanonicalPath()) + "/"]
       return testerLibs.join(' ')


### PR DESCRIPTION
## Motivation

https://github.com/adaptris/interlok-build-parent/issues/92 breaks everyone using build parent if they are foolish enough to upgrade to 4.4.1-RELEASE.

## Modification

- New interlokHelperVersion (naming is hard) which is used primarily to control the explicit version for interlok-varsub
- New 'patch-maps' that map the interlokVersion to specific helper, service-tester, ui versions
    - i.e. interlokVersion=4.4.1-RELEASE, then we use helper=4.4.0-RELEASE, service-tester=4.4.0-RELEASE, ui=4.4.0-RELEASE
- Made interlokTestRuntime extend from interlokRuntime so that it benefits from dependency resolution and eviction.
- Removed the checks for service-tester patching since this is now handled by the patch maps.


## PR Checklist

- [x] been self-reviewed.

## Result

The user isn't broken because they're using the latest release

## Testing

Point your parent gradle to this branches build.gradle

- `gradle -PbuildEnv=dev -PinterlokVersion="4.4.1-RELEASE" dependencies > dependencies.txt` and check your dependencies. Eyeball the interlokWar configuration since you can't check that from the commandline.


- `gradle -PbuildEnv=dev -PinterlokVersion="4.2.0-RELEASE" clean assemble && (cd build/distribution && java -jar lib/interlok-boot.jar --version)` should give you, interlok 4.2.0-RELEASE but service-tester 4.2.1-RELEASE
```
Bootstrap of Interlok 4.2.0-RELEASE(2021-09-03:4.2.0) complete
Version Information
  Interlok Config/variable substitutions: 4.2.0-RELEASE(2021-09-03:4.2.0)
  Interlok Config/xinclude: 4.2.0-RELEASE(2021-09-03:4.2.0)
  Interlok Core/Annotations: 4.2.0-RELEASE(2021-09-03:4.2.0)
  Interlok Core/Base: 4.2.0-RELEASE(2021-09-03:4.2.0)
  Interlok Core/Bootstrap: 4.2.0-RELEASE(2021-09-03:4.2.0)
  Interlok Core/Common: 4.2.0-RELEASE(2021-09-03:4.2.0)
  Interlok Core/Logging: 4.2.0-RELEASE(2021-09-03:4.2.0)
  Interlok Service Tester/Core: 4.2.1-RELEASE(2021-09-14:08:51:24 BST)
```

- `gradle -PbuildEnv=dev -PinterlokVersion="4.4.0-RELEASE" clean assemble && (cd build/distribution && java -jar lib/interlok-boot.jar --version)` gives you 4.4.0-RELEASE of everything.

```
Bootstrap of Interlok 4.4.0-RELEASE(2022-03-01:15:52:14 GMT) complete
Version Information
  Interlok Config/variable substitutions: 4.4.0-RELEASE(2022-03-01:16:03:02 GMT)
  Interlok Config/xinclude: 4.4.0-RELEASE(2022-03-01:16:03:36 GMT)
  Interlok Core/Annotations: 4.4.0-RELEASE(2022-03-01:15:52:14 GMT)
  Interlok Core/Base: 4.4.0-RELEASE(2022-03-01:15:52:14 GMT)
  Interlok Core/Bootstrap: 4.4.0-RELEASE(2022-03-01:15:52:14 GMT)
  Interlok Core/Common: 4.4.0-RELEASE(2022-03-01:15:52:14 GMT)
  Interlok Core/Logging: 4.4.0-RELEASE(2022-03-01:15:52:14 GMT)
  Interlok Service Tester/Core: 4.4.0-RELEASE(2022-03-02:00:11:35 GMT)
```
- `gradle -PbuildEnv=dev -PinterlokVersion="4.5-SNAPSHOT" clean assemble && (cd build/distribution && java -jar lib/interlok-boot.jar --version)` gives you 4.5-SNAPSHOT of everything

```
Bootstrap of Interlok 4.5-SNAPSHOT(2022-03-22:03:24:20 GMT) complete
Version Information
  Interlok Config/variable substitutions: 4.5-SNAPSHOT(2022-03-22:03:37:34 GMT)
  Interlok Config/xinclude: 4.5-SNAPSHOT(2022-03-22:03:38:08 GMT)
  Interlok Core/Annotations: 4.5-SNAPSHOT(2022-03-22:03:24:20 GMT)
  Interlok Core/Base: 4.5-SNAPSHOT(2022-03-22:03:24:20 GMT)
  Interlok Core/Bootstrap: 4.5-SNAPSHOT(2022-03-22:03:24:20 GMT)
  Interlok Core/Common: 4.5-SNAPSHOT(2022-03-22:03:24:20 GMT)
  Interlok Core/Logging: 4.5-SNAPSHOT(2022-03-22:03:24:20 GMT)
  Interlok Service Tester/Core: 4.5-SNAPSHOT(2022-03-22:03:45:03 GMT)
```

- `gradle -PbuildEnv=dev -PinterlokVersion="4.4.1-RELEASE" clean check` gives you 4.4.1 of interlok 4.4.0 of interlok-varsub and service-tester

```
Bootstrap of Interlok 4.4.1-RELEASE(2022-03-16:4.4.1-Support) complete
Version Information
  Interlok Config/variable substitutions: 4.4.0-RELEASE(2022-03-01:16:03:02 GMT)
  Interlok Config/xinclude: 4.4.0-RELEASE(2022-03-01:16:03:36 GMT)
  Interlok Core/Annotations: 4.4.1-RELEASE(2022-03-16:4.4.1-Support)
  Interlok Core/Base: 4.4.1-RELEASE(2022-03-16:4.4.1-Support)
  Interlok Core/Bootstrap: 4.4.1-RELEASE(2022-03-16:4.4.1-Support)
  Interlok Core/Common: 4.4.1-RELEASE(2022-03-16:4.4.1-Support)
  Interlok Core/Logging: 4.4.1-RELEASE(2022-03-16:4.4.1-Support)
  Interlok Service Tester/Core: 4.4.0-RELEASE(2022-03-02:00:11:35 GMT)
```