### PR TITLE
Add additional rename logic to cope with non-semver jars and classifiers

### DIFF
--- a/v3/build.gradle
+++ b/v3/build.gradle
@@ -510,10 +510,14 @@ def renameJarFile(filename, usedFileNames) {
       // hibernate-validator-6.1.7.Final.jar (and netty)
       "Final",
       // Jetty has jetty-continuation-9.4.45.v20220203.jar
-      "v[0-9]+",
+      'v[0-9]+',
       // opendmk_jmxremote_optional_jar-1.0-b01-ea.jar
       // javax.el-3.0.1-b12.jar
-      "b[0-9+].*"
+      '^[ab][0-9]+.*',
+      // org.apache.servicemix.bundles.jzlib-1.0.7_2.jar
+      '_[0-9]+',
+      //scalaz-stream_2.11-0.7.3a.jar
+      '^[ab]$'
     ]
     if (filename ==~ '(.*)\\.jar') {
         def basename=filename.replaceFirst('(.*)\\.jar', '$1')

--- a/v3/build.gradle
+++ b/v3/build.gradle
@@ -504,20 +504,39 @@ distributions {
 }
 
 def renameJarFile(filename, usedFileNames) {
+    def ignorableClassifiers = [
+      "RELEASE-javadoc", "SNAPSHOT-javadoc",
+      "javadoc", "RELEASE", "SNAPSHOT",
+      // hibernate-validator-6.1.7.Final.jar (and netty)
+      "Final",
+      // Jetty has jetty-continuation-9.4.45.v20220203.jar
+      "v[0-9]+",
+      // opendmk_jmxremote_optional_jar-1.0-b01-ea.jar
+      // javax.el-3.0.1-b12.jar
+      "b[0-9+].*"
+    ]
     if (filename ==~ '(.*)\\.jar') {
-        def name = filename.replaceFirst('(.*)-[0-9]+\\.(.*).jar', '$1')
-        def extension = 'jar'
+        def basename=filename.replaceFirst('(.*)\\.jar', '$1')
+        if (filename ==~ '(.*)-[0-9\\.]+(.*).jar') {
+          basename=filename.replaceFirst('(.*)-[0-9\\.]+(.*).jar', '$1')
+          def classifier=filename.replaceFirst('(.*)-[0-9\\.]+(.*).jar', '$2').replaceFirst('-', "")
+          ignorableClassifiers.each {
+            classifier=classifier.replaceFirst(it, "");
+          }
+          if (classifier?.trim()) {
+            basename=basename + "-" + classifier
+          }
+        }
         def isJavadoc = filename ==~ '(.*)-javadoc\\.jar'
-        filename = "${name}.${extension}"
+        filename = "${basename}.jar"
         def index = 1
         // At this point jars and javadoc jars can have the same name
         // so we differentiate them with the boolean 'isJavadoc'
-        while (!usedFileNames.add(filename + " " + isJavadoc)) {
-            filename = "${name}_${index}.${extension}"
+        while (!usedFileNames.add("$filename $isJavadoc")) {
+            filename = "${basename}_${index}.jar"
             index++
         }
     }
-
     return filename
 }
 

--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -88,7 +88,6 @@ ext.buildDetails = [
   isIncludeWar: { ->
     return includeWar.equals("true") || buildEnv.equals("dev")
   }
-
 ]
 
 ext.interlokPatch = [
@@ -571,20 +570,39 @@ distributions {
 }
 
 def renameJarFile(filename, usedFileNames) {
+    def ignorableClassifiers = [
+      "RELEASE-javadoc", "SNAPSHOT-javadoc",
+      "javadoc", "RELEASE", "SNAPSHOT",
+      // hibernate-validator-6.1.7.Final.jar (and netty)
+      "Final",
+      // Jetty has jetty-continuation-9.4.45.v20220203.jar
+      "v[0-9]+",
+      // opendmk_jmxremote_optional_jar-1.0-b01-ea.jar
+      // javax.el-3.0.1-b12.jar
+      "b[0-9+].*"
+    ]
     if (filename ==~ '(.*)\\.jar') {
-        def name = filename.replaceFirst('(.*)-[0-9]+\\.(.*).jar', '$1')
-        def extension = 'jar'
+        def basename=filename.replaceFirst('(.*)\\.jar', '$1')
+        if (filename ==~ '(.*)-[0-9\\.]+(.*).jar') {
+          basename=filename.replaceFirst('(.*)-[0-9\\.]+(.*).jar', '$1')
+          def classifier=filename.replaceFirst('(.*)-[0-9\\.]+(.*).jar', '$2').replaceFirst('-', "")
+          ignorableClassifiers.each {
+            classifier=classifier.replaceFirst(it, "");
+          }
+          if (classifier?.trim()) {
+            basename=basename + "-" + classifier
+          }
+        }
         def isJavadoc = filename ==~ '(.*)-javadoc\\.jar'
-        filename = "${name}.${extension}"
+        filename = "${basename}.jar"
         def index = 1
         // At this point jars and javadoc jars can have the same name
         // so we differentiate them with the boolean 'isJavadoc'
-        while (!usedFileNames.add(filename + " " + isJavadoc)) {
-            filename = "${name}_${index}.${extension}"
+        while (!usedFileNames.add("$filename $isJavadoc")) {
+            filename = "${basename}_${index}.jar"
             index++
         }
     }
-
     return filename
 }
 

--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -576,10 +576,14 @@ def renameJarFile(filename, usedFileNames) {
       // hibernate-validator-6.1.7.Final.jar (and netty)
       "Final",
       // Jetty has jetty-continuation-9.4.45.v20220203.jar
-      "v[0-9]+",
+      'v[0-9]+',
       // opendmk_jmxremote_optional_jar-1.0-b01-ea.jar
       // javax.el-3.0.1-b12.jar
-      "b[0-9+].*"
+      '^[ab][0-9]+.*',
+      // org.apache.servicemix.bundles.jzlib-1.0.7_2.jar
+      '_[0-9]+',
+      //scalaz-stream_2.11-0.7.3a.jar
+      '^[ab]$'
     ]
     if (filename ==~ '(.*)\\.jar') {
         def basename=filename.replaceFirst('(.*)\\.jar', '$1')


### PR DESCRIPTION
## Motivation

- Fixes https://github.com/adaptris/interlok-build-parent/issues/75 
- Fixes https://github.com/adaptris/interlok-build-parent/issues/100

## Modification

Changed the renameJar function so that if the jar name matches a semver expression then we attempt to
- detect the classifier (-javadoc or whatever) and store it for potential later use
- make the basename of the file now myjar-myclassifier.jar before attempting to do the indexing.
- If the jar doesn't match a semver expression then it is renamed as-is.


## PR Checklist

- [x] been self-reviewed.

## Result

No real change, unless the user inspects the contents of the lib directory.
The key noticeable difference is that "listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar is renamed to listenablefuture-empty-to-avoid-conflict-with-guava.jar (One of these optional components introduces that dependency).

```
  interlokRuntime ("com.adaptris:interlok-json:$interlokVersion") { changing=true }
  interlokRuntime ("com.adaptris:interlok-aws-s3:$interlokVersion") { changing=true }
  interlokRuntime ("com.adaptris:interlok-apache-http:$interlokVersion") { changing=true }
  interlokRuntime ("com.adaptris:interlok-rest-health-check:$interlokVersion") { changing=true }
```

## Testing

Use the https://github.com/adaptris-labs/interlok-twilio-sms/tree/develop as your baseline build but point your parent gradle to this branch's build.gradle.

__Make sure you change the target interlok version to be 4.5-SNAPSHOT__

Add in these dependencies (this is to make sure that we explicitly test against what drove https://github.com/adaptris/interlok-build-parent/pull/48)

```gradle
interlokRuntime ("software.amazon.awssdk:json-utils:2.17.52")
interlokRuntime ("com.bazaarvoice.jolt:json-utils:0.1.7")
```

- `gradle -PbuildEnv=dev assemble`

The output in build/distribution/lib should be 
- `xmlresolver.jar + xmlresolver-data.jar` instead of _xmlresolver.jar + xmlresolver_1.jar_ 
- `interlok-twilio-sms.jar` rather than _interlok-twilio-sms-4-SNAPSHOT.jar.jar_
- `json_utils.jar + json_utils_1.jar` exist as expected.