### PR TITLE
updating interlok-verify-report to 3.1.0 

### DIFF
--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -273,7 +273,7 @@ dependencies {
   interlokJavadocs group: "com.adaptris", name: "interlok-core", version: "$interlokVersion", classifier: "javadoc", changing: true, transitive: false
   interlokJavadocs group: "com.adaptris", name: "interlok-common", version: "$interlokVersion", classifier: "javadoc", changing: true, transitive: false
 
-  interlokVerifyReport("com.adaptris:interlok-verify-report:3.0.0")
+  interlokVerifyReport("com.adaptris:interlok-verify-report:3.1.0")
 
   antJunit ("org.apache.ant:ant-junit:1.10.12")
 }


### PR DESCRIPTION
updating interlok-verify-report to 3.1.0 (which has dependence updates)