### PR TITLE
Update build.gradle

### DIFF
--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -488,7 +488,7 @@ task interlokServiceTestReport {
     group = 'Test'
     description = 'Create Interlok service test reports'
     onlyIf{
-      interlokServiceTest.get().didWork
+      interlokServiceTest.get().didWork && new File(interlokServiceTestOutput).exists()
     }
     doLast {
       mkdir interlokServiceTestReportDir


### PR DESCRIPTION
## Motivation

When running gradlew clean build in an interlok project:

If the project has a service-test.xml but the file does not have any tests no junit test xml report will be generated . This will cause the build to fail with an NPE because the report dir doesn’t not exist.

## Modification

Check to see if the dir exist before running ant.junitreport

## PR Checklist

- [x] been self-reviewed.

## Result

The build will keep going if there is no test in the service-test.xml

## Testing

Run gradlew clean build in a project that has a service-test.xml with no tests.