### PR TITLE
Pin slf4j to 1.7.36 to avoid multi logging subsystems in play.

### DIFF
--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -17,7 +17,7 @@ ext {
   localInterlokRepo = project.findProperty('localInterlokRepo') ?: 'unknown'
   nexusBaseUrl  = 'https://nexus.adaptris.net'
   log4j2Version='2.18.0'
-  slf4jVersion='2.0.1'
+  slf4jVersion='1.7.36'
   // Make semi-required optional components have an explicit version
   interlokVersion = project.findProperty('interlokVersion') ?: '4.5.0-RELEASE'
   interlokHelperVersion = project.findProperty('interlokVersion') ?: interlokVersion
@@ -251,13 +251,31 @@ dependencies {
   interlokRuntime ("com.adaptris:interlok-logging:$interlokVersion") { changing=true }
   interlokRuntime group: "com.adaptris", name: "interlok-varsub", version: interlokPatch.helperVersion(), changing: true
 
-  interlokRuntime ("org.slf4j:slf4j-api:$slf4jVersion")
-  interlokRuntime ("org.slf4j:jcl-over-slf4j:$slf4jVersion")
-  interlokRuntime ("org.slf4j:jul-to-slf4j:$slf4jVersion")
-  interlokRuntime ("org.apache.logging.log4j:log4j-core:$log4j2Version")
-  interlokRuntime ("org.apache.logging.log4j:log4j-1.2-api:$log4j2Version")
-  interlokRuntime ("org.apache.logging.log4j:log4j-slf4j-impl:$log4j2Version")
-  interlokRuntime ("org.apache.logging.log4j:log4j-api:$log4j2Version")
+  interlokRuntime ("org.slf4j:slf4j-api") {
+    version {
+      strictly "$slf4jVersion"
+      because "log4j-slf4j18-impl is not compatible with slf4j2.x until 2.19+"
+    }
+  }
+  interlokRuntime ("org.slf4j:jcl-over-slf4j:$slf4jVersion")  {
+    version {
+      strictly "$slf4jVersion"
+      because "log4j-slf4j18-impl is not compatible with slf4j2.x until 2.19+"
+    }
+  }
+  interlokRuntime ("org.slf4j:jul-to-slf4j:$slf4jVersion") {
+    version {
+      strictly "$slf4jVersion"
+      because "log4j-slf4j18-impl is not compatible with slf4j2.x 2.19+"
+    }
+  }
+
+  interlokRuntime (platform("org.apache.logging.log4j:log4j-bom:$log4j2Version"))
+  interlokRuntime ("org.apache.logging.log4j:log4j-core")
+  interlokRuntime ("org.apache.logging.log4j:log4j-1.2-api")
+  interlokRuntime ("org.apache.logging.log4j:log4j-slf4j-impl")
+  interlokRuntime ("org.apache.logging.log4j:log4j-api")
+
   interlokRuntime ("com.sun.mail:jakarta.mail:1.6.7")
   interlokRuntime ("com.sun.activation:jakarta.activation:1.2.2")
   interlokRuntime ("jakarta.validation:jakarta.validation-api:2.0.2")


### PR DESCRIPTION
## Motivation

See https://github.com/adaptris/interlok-build-parent/issues/130

Pin SLF4J to 1.7.36 because bumping to 2.0 causes some runtime issues vis-a-vis the log4j2 binding (log4j-slf4j18-impl isn't quite right, and they expect to release a log4j-slf4j20-impl for log4j2-2.19).

Force a strict pin because internally 'interlok-core' has bumped to slf4j-2.0 so we don't want optimistic upgrades to happen.

## Modification

- Pinned SLF4J to 1.7.36 with a strict version (no bom sadly)
- Switch to using the log4j2 bom

## PR Checklist

- [x] been self-reviewed.

## Result

Actual logging output

## Testing

- Follow instructions in https://github.com/adaptris/interlok-build-parent/issues/130; see that there is no logging
- Switch to this branch instead.
- Check that jar (slf4j-api.jar) is pinned at 1.7.36


