### PR TITLE
INTERLOK-3924 Upgrade to slf4j 2.0.3 and remove pin to slf4j 1.7.36

### DIFF
--- a/v3/build.gradle
+++ b/v3/build.gradle
@@ -17,7 +17,7 @@ ext {
   localInterlokRepo = project.findProperty('localInterlokRepo') ?: 'unknown'
   nexusBaseUrl  = 'https://nexus.adaptris.net'
   log4j2Version='2.19.0'
-  slf4jVersion='1.7.36'
+  slf4jVersion='2.0.3'
   interlokVersion = project.findProperty('interlokVersion') ?: '3.12.0-RELEASE'
   // interlok-core is patched to 3.12.0.3-RELEASE
   // Check the if statement in the dependencies block.
@@ -204,29 +204,14 @@ dependencies {
   }
   interlokRuntime ("com.adaptris:interlok-varsub:$interlokVersion") { changing=true }
 
-  interlokRuntime ("org.slf4j:slf4j-api") {
-    version {
-      strictly "$slf4jVersion"
-      because "log4j-slf4j18-impl is not compatible with slf4j2.x until 2.19+"
-    }
-  }
-  interlokRuntime ("org.slf4j:jcl-over-slf4j:$slf4jVersion")  {
-    version {
-      strictly "$slf4jVersion"
-      because "log4j-slf4j18-impl is not compatible with slf4j2.x until 2.19+"
-    }
-  }
-  interlokRuntime ("org.slf4j:jul-to-slf4j:$slf4jVersion") {
-    version {
-      strictly "$slf4jVersion"
-      because "log4j-slf4j18-impl is not compatible with slf4j2.x 2.19+"
-    }
-  }
+  interlokRuntime ("org.slf4j:slf4j-api:$slf4jVersion")
+  interlokRuntime ("org.slf4j:jcl-over-slf4j:$slf4jVersion")
+  interlokRuntime ("org.slf4j:jul-to-slf4j:$slf4jVersion");
 
   interlokRuntime (platform("org.apache.logging.log4j:log4j-bom:$log4j2Version"))
   interlokRuntime ("org.apache.logging.log4j:log4j-core")
   interlokRuntime ("org.apache.logging.log4j:log4j-1.2-api")
-  interlokRuntime ("org.apache.logging.log4j:log4j-slf4j-impl")
+  interlokRuntime ("org.apache.logging.log4j:log4j-slf4j2-impl")
   interlokRuntime ("org.apache.logging.log4j:log4j-api")
 
   interlokRuntime ("com.sun.mail:jakarta.mail:1.6.7")

--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -17,7 +17,7 @@ ext {
   localInterlokRepo = project.findProperty('localInterlokRepo') ?: 'unknown'
   nexusBaseUrl  = 'https://nexus.adaptris.net'
   log4j2Version='2.19.0'
-  slf4jVersion='1.7.36'
+  slf4jVersion='2.0.3'
   // Make semi-required optional components have an explicit version
   interlokVersion = project.findProperty('interlokVersion') ?: '4.5.0-RELEASE'
   interlokHelperVersion = project.findProperty('interlokVersion') ?: interlokVersion
@@ -251,29 +251,14 @@ dependencies {
   interlokRuntime ("com.adaptris:interlok-logging:$interlokVersion") { changing=true }
   interlokRuntime group: "com.adaptris", name: "interlok-varsub", version: interlokPatch.helperVersion(), changing: true
 
-  interlokRuntime ("org.slf4j:slf4j-api") {
-    version {
-      strictly "$slf4jVersion"
-      because "log4j-slf4j18-impl is not compatible with slf4j2.x until 2.19+"
-    }
-  }
-  interlokRuntime ("org.slf4j:jcl-over-slf4j:$slf4jVersion")  {
-    version {
-      strictly "$slf4jVersion"
-      because "log4j-slf4j18-impl is not compatible with slf4j2.x until 2.19+"
-    }
-  }
-  interlokRuntime ("org.slf4j:jul-to-slf4j:$slf4jVersion") {
-    version {
-      strictly "$slf4jVersion"
-      because "log4j-slf4j18-impl is not compatible with slf4j2.x 2.19+"
-    }
-  }
+  interlokRuntime ("org.slf4j:slf4j-api:$slf4jVersion")
+  interlokRuntime ("org.slf4j:jcl-over-slf4j:$slf4jVersion")
+  interlokRuntime ("org.slf4j:jul-to-slf4j:$slf4jVersion")
 
   interlokRuntime (platform("org.apache.logging.log4j:log4j-bom:$log4j2Version"))
   interlokRuntime ("org.apache.logging.log4j:log4j-core")
   interlokRuntime ("org.apache.logging.log4j:log4j-1.2-api")
-  interlokRuntime ("org.apache.logging.log4j:log4j-slf4j-impl")
+  interlokRuntime ("org.apache.logging.log4j:log4j-slf4j2-impl")
   interlokRuntime ("org.apache.logging.log4j:log4j-api")
 
   interlokRuntime ("com.sun.mail:jakarta.mail:1.6.7")


### PR DESCRIPTION
## Motivation

## Why am I doing this
The PR [Pin slf4j to 1.7.36 to avoid multi logging subsystems in play](https://github.com/adaptris/interlok-build-parent/pull/131) added a workaround to fix the issue with Slf4j 2.0.0 described in [https://github.com/adaptris/interlok-build-parent/issues/130](https://github.com/adaptris/interlok-build-parent/issues/130)

This resolves [https://github.com/adaptris/interlok-build-parent/issues/130](https://github.com/adaptris/interlok-build-parent/issues/130)

## Modification

- Upgrade to slf4j 2.0.3
- Remove pin to version 1.7.36
- Use log4j-slf4j2-impl instead of log4j-slf4j-impl

## PR Checklist

- [x] been self-reviewed.

## Result

Logging output is working

## Testing

- Follow instructions in https://github.com/adaptris/interlok-build-parent/issues/130 using this branch and check that there is some logging.
Check that slf4j-api.jar is 2.0.3
