### PR TITLE
INTERLOK-4120 Remove Alpha and Beta versions from jar file names

### DIFF
--- a/v3/build.gradle
+++ b/v3/build.gradle
@@ -25,14 +25,18 @@ ext {
   requiresCorePatchVersion = "3.12.0-RELEASE"
 
   verifyReportConfigCheckAvailable = '3.12-SNAPSHOT'
+  
   interlokUiVersion = project.findProperty('interlokUiVersion') ?: interlokVersion
+  
   interlokSourceConfig = "${projectDir}/src/main/interlok/config"
   interlokTmpConfigDirectory = "${buildDir}/tmp/config"
   interlokTmpLibDirectory = "${buildDir}/tmp/lib"
   interlokTmpWarDirectory = "${buildDir}/tmp/war"
   interlokTmpDocsDirectory = "${buildDir}/tmp/docs"
   interlokTmpServiceTestLog4j = "${buildDir}/tmp/serviceTestLog4j/log4j2.xml"
+  
   interlokDistDirectory = project.findProperty('interlokDistDirectory') ?: "${buildDir}/distribution"
+  
   buildEnv = project.findProperty('buildEnv') ?: 'NoBuildEnv'
   includeWar = project.findProperty('includeWar') ?: 'false'
   additionalTemplatedConfiguration = project.findProperty('additionalTemplatedConfiguration') ?: []
@@ -496,12 +500,13 @@ distributions {
             into('docs/javadocs') {
               from(interlokJavadocsDist)
             }
-            // Doing: rename '(.*)-[0-9]+\\..*.jar', '$1.jar'
+            // Doing: rename '(.*)-[0-9\\.AB]+\\..*.jar', '$1.jar'
+            // AB is for Alpha or Beta versions
             // but also add an index if a file name already exists
             rename { filename ->
                 return renameJarFile(filename, usedFileNames)
             }
-            rename '(.*)-[0-9]+\\..*.war', '$1.war'
+            rename '(.*)-[0-9\\.AB]+\\..*.war', '$1.war'
             duplicatesStrategy = DuplicatesStrategy.EXCLUDE
         }
     }
@@ -524,10 +529,12 @@ def renameJarFile(filename, usedFileNames) {
       '^[ab]$'
     ]
     if (filename ==~ '(.*)\\.jar') {
+        // AB is for Alpha or Beta versions
+	    def jarNamePattern = '(.*)-[0-9\\.AB]+(.*).jar'
         def basename=filename.replaceFirst('(.*)\\.jar', '$1')
-        if (filename ==~ '(.*)-[0-9\\.]+(.*).jar') {
-          basename=filename.replaceFirst('(.*)-[0-9\\.]+(.*).jar', '$1')
-          def classifier=filename.replaceFirst('(.*)-[0-9\\.]+(.*).jar', '$2').replaceFirst('-', "")
+        if (filename ==~ jarNamePattern) {
+          basename=filename.replaceFirst(jarNamePattern, '$1')
+          def classifier=filename.replaceFirst(jarNamePattern, '$2').replaceFirst('-', "")
           ignorableClassifiers.each {
             classifier=classifier.replaceFirst(it, "");
           }

--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -561,12 +561,13 @@ distributions {
             into('docs/javadocs') {
               from(interlokJavadocsDist)
             }
-            // Doing: rename '(.*)-[0-9]+\\..*.jar', '$1.jar'
+            // Doing: rename '(.*)-[0-9\\.AB]+\\..*.jar', '$1.jar'
+            // AB is for Alpha or Beta versions
             // but also add an index if a file name already exists
             rename { filename ->
                 return renameJarFile(filename, usedFileNames)
             }
-            rename '(.*)-[0-9]+\\..*.war', '$1.war'
+            rename '(.*)-[0-9\\.AB]+\\..*.war', '$1.war'
             duplicatesStrategy = DuplicatesStrategy.EXCLUDE
         }
     }
@@ -589,10 +590,12 @@ def renameJarFile(filename, usedFileNames) {
       '^[ab]$'
     ]
     if (filename ==~ '(.*)\\.jar') {
+        // AB is for Alpha or Beta versions
+	    def jarNamePattern = '(.*)-[0-9\\.AB]+(.*).jar'
         def basename=filename.replaceFirst('(.*)\\.jar', '$1')
-        if (filename ==~ '(.*)-[0-9\\.]+(.*).jar') {
-          basename=filename.replaceFirst('(.*)-[0-9\\.]+(.*).jar', '$1')
-          def classifier=filename.replaceFirst('(.*)-[0-9\\.]+(.*).jar', '$2').replaceFirst('-', "")
+        if (filename ==~ jarNamePattern) {
+          basename=filename.replaceFirst(jarNamePattern, '$1')
+          def classifier=filename.replaceFirst(jarNamePattern, '$2').replaceFirst('-', "")
           ignorableClassifiers.each {
             classifier=classifier.replaceFirst(it, "");
           }

--- a/v5/build.gradle
+++ b/v5/build.gradle
@@ -561,12 +561,13 @@ distributions {
             into('docs/javadocs') {
               from(interlokJavadocsDist)
             }
-            // Doing: rename '(.*)-[0-9]+\\..*.jar', '$1.jar'
+            // Doing: rename '(.*)-[0-9\\.AB]+\\..*.jar', '$1.jar'
+            // AB is for Alpha or Beta versions
             // but also add an index if a file name already exists
             rename { filename ->
                 return renameJarFile(filename, usedFileNames)
             }
-            rename '(.*)-[0-9]+\\..*.war', '$1.war'
+            rename '(.*)-[0-9\\.AB]+\\..*.war', '$1.war'
             duplicatesStrategy = DuplicatesStrategy.EXCLUDE
         }
     }
@@ -589,10 +590,12 @@ def renameJarFile(filename, usedFileNames) {
       '^[ab]$'
     ]
     if (filename ==~ '(.*)\\.jar') {
+        // AB is for Alpha or Beta versions
+	    def jarNamePattern = '(.*)-[0-9\\.AB]+(.*).jar'
         def basename=filename.replaceFirst('(.*)\\.jar', '$1')
-        if (filename ==~ '(.*)-[0-9\\.]+(.*).jar') {
-          basename=filename.replaceFirst('(.*)-[0-9\\.]+(.*).jar', '$1')
-          def classifier=filename.replaceFirst('(.*)-[0-9\\.]+(.*).jar', '$2').replaceFirst('-', "")
+        if (filename ==~ jarNamePattern) {
+          basename=filename.replaceFirst(jarNamePattern, '$1')
+          def classifier=filename.replaceFirst(jarNamePattern, '$2').replaceFirst('-', "")
           ignorableClassifiers.each {
             classifier=classifier.replaceFirst(it, "");
           }


### PR DESCRIPTION
## Motivation

When we do a beta release the beta version remain in the jar name. This cause the start script to not work because it expects interlok-boot.jar and not interlok-boot-B1.jar

## Modification

Change the rename regex to take A1, A2, B1, B2 ... into account

## PR Checklist

- [x] been self-reviewed.

## Result

Interlok jars are named correctly even in Beta versions.

## Testing

We can test with v4 as we have some Beta release:
Install an instance of interlok 4.8.0B1-RELEASE with as much as optional as you can.
Check the names of interlok jar files they should have B1. Also check the number of jars.
Do the same thing using the build parent from this PR's branch.
You should have the same jar files (same number) but all the interlok jar should be names without B1.
