### PR TITLE
Added mandatory environment checks

### DIFF
--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -627,15 +627,33 @@ installDist {
 //   }
 // }
 
-task checkJavaVersion {
+task checkDeveloperEnv {
+  description = 'Check minimum environment configurations'
   doLast {
-    if (interlokVersion.startsWith("4")) {
-      if (JavaVersion.current().ordinal() < JavaVersion.VERSION_11.ordinal()) {
-        throw new GradleException("We're running with " + JavaVersion.current() + " and not Java 11")
-      }
+    // Check Java version, we should be on 11 at least
+    if (JavaVersion.current().ordinal() < JavaVersion.VERSION_11.ordinal()) {
+      project.logger.error("Running with older Java version: "+ JavaVersion.current())
+      throw new GradleException("Environment not configured with a min of JDK 11!")
     }
+    
+    // Check interlok version, should be 4+
+    if (!interlokVersion.startsWith("4")) {
+      project.logger.error("InterlokVersion set to: $interlokVersion")
+      throw new GradleException("Need to be configured to build V4 Interlok!")
+    }
+    
+    // Check the gradle version being used.
+    def gradleVersion = VersionNumber.parse(gradle.gradleVersion)
+    String gradleToggleUrl = "https://gitlab.proagrica-tooling.dev/devops/config/toggles/-/raw/master/src/gradle/stable"
+    def toggleGradleVersion = VersionNumber.parse(gradleToggleUrl.toURL().text)
+    if (gradleVersion.getMajor() < toggleGradleVersion.getMajor()) {
+      throw new GradleException("Environment not configured with recommended gradle version of: $toggleGradleVersion!")
+    }
+    
+    project.logger.info("Developer environment is well configured")
   }
 }
+
 
 dependencyCheck  {
   suppressionFiles= [ "https://raw.githubusercontent.com/adaptris/interlok/develop/gradle/owasp-exclude.xml" ]
@@ -648,5 +666,5 @@ dependencyCheck  {
 }
 
 // check.dependsOn dependencyCheckAnalyze,interlokVerify,interlokServiceTest,interlokVersionReport
-check.dependsOn checkJavaVersion,interlokVerify,interlokServiceTest,interlokVersionReport
+check.dependsOn checkDeveloperEnv,interlokVerify,interlokServiceTest,interlokVersionReport
 assemble.dependsOn installDist


### PR DESCRIPTION
## Motivation

Added minimum environment checks to check that developer has all the minimum required tools to build the project.

## Modification

I am checking the Gradle toggle url on the tooling platform to identify the min Gradle version required.

## PR Checklist

- [x] been self-reviewed.
- [ ] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [ ] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

What's the end result for the user

## Testing

How can I test this if I'm reviewing this.
