### PR TITLE
Remove version number from license and lic files when pulled from nexus as dependency.

### DIFF
--- a/v4/build.gradle
+++ b/v4/build.gradle
@@ -568,7 +568,7 @@ distributions {
             rename { filename ->
                 return renameJarFile(filename, usedFileNames)
             }
-            rename '(.*)-[0-9\\.AB]+\\..*.war', '$1.war'
+            rename '(.*)-[0-9\\.AB]+\\..*.(war|lic|license)', '$1.$2'
             duplicatesStrategy = DuplicatesStrategy.EXCLUDE
         }
     }

--- a/v5/build.gradle
+++ b/v5/build.gradle
@@ -571,7 +571,7 @@ distributions {
             rename { filename ->
                 return renameJarFile(filename, usedFileNames)
             }
-            rename '(.*)-[0-9\\.AB]+\\..*.war', '$1.war'
+            rename '(.*)-[0-9\\.AB]+\\..*.(war|lic|license)', '$1.$2'
             duplicatesStrategy = DuplicatesStrategy.EXCLUDE
         }
     }


### PR DESCRIPTION
## Motivation

We need to be able to fetch SaxonEE license file from nexus and add it to the lib dir.
The file name needs to be `saxon-license.lic` to be picked up by saxonee.jar.

## Modification

Modify the war rename regex to also rename and remove version numbers from .lic and .license files.

## Result

If we have a .lic or a .license file as dependency the version will be removed when added to the lib dir

## Testing

If you have a lic file in nexus you can add it as a dependency into a build.gradle file like any jar:

i.e.

`interlokRuntime ("com.adaptris.net.sf.saxon:saxon-license:1.0.0") { changing=true }`

When you run `gradle build`, you should see saxon-license.lic in the lib dir.