### PR TITLE
bumped jackson patch version

### DIFF
--- a/v5/build.gradle
+++ b/v5/build.gradle
@@ -18,6 +18,7 @@ ext {
   nexusBaseUrl  = 'https://nexus.adaptris.net'
   log4j2Version='2.24.3'
   slf4jVersion='2.0.16'
+  jacksonVersion='2.22.1'
   // Make semi-required optional components have an explicit version
   interlokVersion = project.findProperty('interlokVersion') ?: '5.0.3-RELEASE'
   interlokHelperVersion = project.findProperty('interlokVersion') ?: interlokVersion
@@ -244,6 +245,9 @@ repositories {
 }
 
 dependencies {
+  interlokRuntime (platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
+  interlokWar (platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
+
   interlokRuntime ("com.adaptris:interlok-core:$interlokVersion") { changing= true}
   interlokRuntime ("com.adaptris:interlok-common:$interlokVersion") { changing= true}
   interlokRuntime ("com.adaptris:interlok-boot:$interlokVersion") { changing=true }


### PR DESCRIPTION
This pull request updates the dependency management in the `v5/build.gradle` file to explicitly add and version the Jackson library using a BOM (Bill of Materials). The main focus is to ensure consistent and up-to-date Jackson versions across the build.

**Dependency management improvements:**

* Added a new `jacksonVersion` property set to `2.22.1` to the `ext` block for centralized version control.
* Applied the Jackson BOM (`com.fasterxml.jackson:jackson-bom:$jacksonVersion`) to both `interlokRuntime` and `interlokWar` configurations, ensuring all Jackson dependencies use the specified version.