### PR TITLE
reverted bumped jackson patch version

### DIFF
--- a/v5/build.gradle
+++ b/v5/build.gradle
@@ -18,7 +18,6 @@ ext {
   nexusBaseUrl  = 'https://nexus.adaptris.net'
   log4j2Version='2.24.3'
   slf4jVersion='2.0.16'
-  jacksonVersion='2.22.1'
   // Make semi-required optional components have an explicit version
   interlokVersion = project.findProperty('interlokVersion') ?: '5.0.3-RELEASE'
   interlokHelperVersion = project.findProperty('interlokVersion') ?: interlokVersion
@@ -245,9 +244,6 @@ repositories {
 }
 
 dependencies {
-  interlokRuntime (platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
-  interlokWar (platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
-
   interlokRuntime ("com.adaptris:interlok-core:$interlokVersion") { changing= true}
   interlokRuntime ("com.adaptris:interlok-common:$interlokVersion") { changing= true}
   interlokRuntime ("com.adaptris:interlok-boot:$interlokVersion") { changing=true }


### PR DESCRIPTION
This pull request simplifies the dependency management for the `v5/build.gradle` file by removing the explicit Jackson version and its associated BOM (Bill of Materials) platform dependencies. This change likely delegates Jackson version management to the transitive dependencies of Interlok or another BOM, reducing redundancy and potential version conflicts.

Dependency management simplification:

* Removed the `jacksonVersion` property from the `ext` block, so Jackson version is no longer explicitly defined in the build script.
* Removed the `jackson-bom` platform dependencies from both `interlokRuntime` and `interlokWar` configurations, streamlining dependency declarations.